### PR TITLE
Add signup workflow with email authentication and invite codes

### DIFF
--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -16,6 +16,7 @@ class User(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     home_id: int = Field(foreign_key="home.id", index=True)
     username: str = Field(index=True, min_length=1, max_length=50)
+    email: Optional[str] = Field(default=None, unique=True, index=True)
     password_hash: str
     level: int = Field(default=1, ge=1, le=1000)
     xp: int = Field(default=0, ge=0)
@@ -35,6 +36,7 @@ class UserRead(SQLModel):
     id: int
     home_id: int
     username: str
+    email: Optional[str] = None
     level: int
     xp: int
     gold_balance: int
@@ -45,6 +47,7 @@ class UserCreate(SQLModel):
     """Schema for creating a user"""
 
     username: str = Field(min_length=1, max_length=50)
+    email: Optional[str] = None
     password: str = Field(min_length=1)
 
 

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -3,12 +3,16 @@
 import os
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, EmailStr
 from sqlmodel import Session
 
 from app.auth import create_access_token, verify_password
+from app.crud import home as crud_home
 from app.crud import user as crud_user
 from app.database import get_db
+from app.errors import ErrorCode, create_error_detail
+from app.models.home import HomeCreate
+from app.models.user import UserCreate
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])
 
@@ -17,6 +21,24 @@ class LoginRequest(BaseModel):
     username: str
     password: str
     home_id: int
+
+
+class LoginEmailRequest(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class SignupRequest(BaseModel):
+    email: EmailStr
+    password: str
+    home_name: str
+
+
+class JoinHomeRequest(BaseModel):
+    invite_code: str
+    email: EmailStr
+    username: str
+    password: str
 
 
 @router.post("/login")
@@ -39,6 +61,136 @@ def login(request: LoginRequest, db: Session = Depends(get_db)):
 
     token = create_access_token(user.id, user.home_id)
     return {"access_token": token, "token_type": "bearer", "user_id": user.id, "home_id": user.home_id}
+
+
+@router.post("/login-email")
+def login_email(request: LoginEmailRequest, db: Session = Depends(get_db)):
+    """
+    Authenticate user with email and return JWT access token.
+
+    - **email**: User's email address (globally unique)
+    - **password**: User's password
+
+    Returns access token for authenticated API requests.
+    Include token in subsequent requests: `Authorization: Bearer <token>`
+    """
+    # Find user by email
+    user = crud_user.get_user_by_email(db, request.email)
+
+    if not user or not verify_password(request.password, user.password_hash):
+        raise HTTPException(
+            status_code=401,
+            detail=create_error_detail(
+                ErrorCode.INVALID_CREDENTIALS, message="Invalid email or password", details={"email": request.email}
+            ),
+        )
+
+    token = create_access_token(user.id, user.home_id)
+    return {"access_token": token, "token_type": "bearer", "user_id": user.id, "home_id": user.home_id}
+
+
+@router.post("/signup")
+def signup(request: SignupRequest, db: Session = Depends(get_db)):
+    """
+    Create a new home and user account, return JWT access token.
+
+    - **email**: User's email address (will be globally unique)
+    - **password**: User's password
+    - **home_name**: Name for the new home/household
+
+    Creates a new home with auto-generated invite code and registers the user as the first member.
+    Returns access token for immediate login.
+    """
+    try:
+        # Create the home
+        home = crud_home.create_home(db, HomeCreate(name=request.home_name))
+
+        # Generate username from email (use part before @)
+        username = request.email.split("@")[0]
+
+        # Create the user (first member of the home)
+        user = crud_user.create_user(db, home.id, UserCreate(username=username, email=request.email, password=request.password))
+
+        # Return token for immediate login
+        token = create_access_token(user.id, user.home_id)
+        return {
+            "access_token": token,
+            "token_type": "bearer",
+            "user_id": user.id,
+            "home_id": user.home_id,
+            "invite_code": home.invite_code,
+        }
+
+    except ValueError as e:
+        error_msg = str(e)
+        if "already exists" in error_msg.lower():
+            if "email" in error_msg.lower():
+                raise HTTPException(
+                    status_code=400,
+                    detail=create_error_detail(
+                        ErrorCode.DUPLICATE_USERNAME, message=error_msg, details={"email": request.email}
+                    ),
+                )
+            else:
+                raise HTTPException(
+                    status_code=400,
+                    detail=create_error_detail(
+                        ErrorCode.DUPLICATE_HOME_NAME, message=error_msg, details={"home_name": request.home_name}
+                    ),
+                )
+        raise HTTPException(status_code=400, detail=create_error_detail(ErrorCode.INVALID_INPUT, message=error_msg))
+
+
+@router.post("/join")
+def join_home(request: JoinHomeRequest, db: Session = Depends(get_db)):
+    """
+    Join an existing home using an invite code.
+
+    - **invite_code**: Unique invite code for the home
+    - **email**: User's email address (globally unique)
+    - **username**: Display name for the user (unique within the home)
+    - **password**: User's password
+
+    Returns access token for immediate login.
+    """
+    # Find home by invite code
+    home = crud_home.get_home_by_invite_code(db, request.invite_code)
+    if not home:
+        raise HTTPException(
+            status_code=404,
+            detail=create_error_detail(
+                ErrorCode.HOME_NOT_FOUND, message="Invalid invite code", details={"invite_code": request.invite_code}
+            ),
+        )
+
+    try:
+        # Create the user
+        user = crud_user.create_user(
+            db, home.id, UserCreate(username=request.username, email=request.email, password=request.password)
+        )
+
+        # Return token for immediate login
+        token = create_access_token(user.id, user.home_id)
+        return {"access_token": token, "token_type": "bearer", "user_id": user.id, "home_id": user.home_id}
+
+    except ValueError as e:
+        error_msg = str(e)
+        if "already exists" in error_msg.lower() or "already registered" in error_msg.lower():
+            if "email" in error_msg.lower():
+                raise HTTPException(
+                    status_code=400,
+                    detail=create_error_detail(
+                        ErrorCode.DUPLICATE_USERNAME, message=error_msg, details={"email": request.email}
+                    ),
+                )
+            else:
+                raise HTTPException(
+                    status_code=400,
+                    detail=create_error_detail(
+                        ErrorCode.DUPLICATE_USERNAME, message=error_msg, details={"username": request.username}
+                    ),
+                )
+        raise HTTPException(status_code=400, detail=create_error_detail(ErrorCode.INVALID_INPUT, message=error_msg))
 
 
 @router.get("/dev/token")

--- a/backend/migrations/versions/add_email_to_user.py
+++ b/backend/migrations/versions/add_email_to_user.py
@@ -1,0 +1,29 @@
+"""Add email field to user table
+
+Revision ID: add_email_001
+Revises: add_tags_001
+Create Date: 2026-01-13
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "add_email_001"
+down_revision = "add_tags_001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add email column - nullable for backward compatibility, unique for global uniqueness
+    op.add_column("user", sa.Column("email", sa.String(), nullable=True))
+    # Create unique index on email (ignoring NULL values)
+    op.create_index(op.f("ix_user_email"), "user", ["email"], unique=True)
+
+
+def downgrade() -> None:
+    # Remove email index and column
+    op.drop_index(op.f("ix_user_email"), table_name="user")
+    op.drop_column("user", "email")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "python-jose[cryptography]>=3.3.0",
     "bcrypt>=4.1.1",
     "groq>=0.4.2",
+    "email-validator>=2.3.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -370,6 +370,30 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/4a/263763cb2ba3816dd94b08ad3a33d5fdae34ecb856678773cc40a3605829/dnspython-2.7.0.tar.gz", hash = "sha256:ce9c432eda0dc91cf618a5cedf1a4e142651196bbcd2c80e89ed5a907e5cfaf1", size = 345197, upload-time = "2024-10-05T20:14:59.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/1b/e0a87d256e40e8c888847551b20a017a6b98139178505dc7ffb96f04e954/dnspython-2.7.0-py3-none-any.whl", hash = "sha256:b4c34b7d10b51bcc3a5071e7b8dee77939f1e878477eeecc965e9835f63c6c86", size = 313632, upload-time = "2024-10-05T20:14:57.687Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -379,6 +403,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/1f/924e3caae75f471eae4b26bd13b698f6af2c44279f67af317439c2f4c46a/ecdsa-0.19.1.tar.gz", hash = "sha256:478cba7b62555866fcb3bb3fe985e06decbdb68ef55713c4e5ab98c57d508e61", size = 201793, upload-time = "2025-03-13T11:52:43.25Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/a3/460c57f094a4a165c84a1341c373b0a4f5ec6ac244b998d5021aade89b77/ecdsa-0.19.1-py2.py3-none-any.whl", hash = "sha256:30638e27cf77b7e15c4c4cc1973720149e1033827cfd00661ca5c8cc0cdb24c3", size = 150607, upload-time = "2025-03-13T11:52:41.757Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython", version = "2.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "dnspython", version = "2.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
 ]
 
 [[package]]
@@ -421,6 +459,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/ed/6bfa4109fcb23a58819600392564fea69cdc6551ffd5e69ccf1d52a40cbc/greenlet-3.2.4-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:8c68325b0d0acf8d91dde4e6f930967dd52a5302cd4062932a6b2e7c2969f47c", size = 271061, upload-time = "2025-08-07T13:17:15.373Z" },
     { url = "https://files.pythonhosted.org/packages/2a/fc/102ec1a2fc015b3a7652abab7acf3541d58c04d3d17a8d3d6a44adae1eb1/greenlet-3.2.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:94385f101946790ae13da500603491f04a76b6e4c059dab271b3ce2e283b2590", size = 629475, upload-time = "2025-08-07T13:42:54.009Z" },
     { url = "https://files.pythonhosted.org/packages/c5/26/80383131d55a4ac0fb08d71660fd77e7660b9db6bdb4e8884f46d9f2cc04/greenlet-3.2.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f10fd42b5ee276335863712fa3da6608e93f70629c631bf77145021600abc23c", size = 640802, upload-time = "2025-08-07T13:45:25.52Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/7c/e7833dbcd8f376f3326bd728c845d31dcde4c84268d3921afcae77d90d08/greenlet-3.2.4-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c8c9e331e58180d0d83c5b7999255721b725913ff6bc6cf39fa2a45841a4fd4b", size = 636703, upload-time = "2025-08-07T13:53:12.622Z" },
     { url = "https://files.pythonhosted.org/packages/e9/49/547b93b7c0428ede7b3f309bc965986874759f7d89e4e04aeddbc9699acb/greenlet-3.2.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:58b97143c9cc7b86fc458f215bd0932f1757ce649e05b640fea2e79b54cedb31", size = 635417, upload-time = "2025-08-07T13:18:25.189Z" },
     { url = "https://files.pythonhosted.org/packages/7f/91/ae2eb6b7979e2f9b035a9f612cf70f1bf54aad4e1d125129bef1eae96f19/greenlet-3.2.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c2ca18a03a8cfb5b25bc1cbe20f3d9a4c80d8c3b13ba3df49ac3961af0b1018d", size = 584358, upload-time = "2025-08-07T13:18:23.708Z" },
     { url = "https://files.pythonhosted.org/packages/f7/85/433de0c9c0252b22b16d413c9407e6cb3b41df7389afc366ca204dbc1393/greenlet-3.2.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:9fe0a28a7b952a21e2c062cd5756d34354117796c6d9215a87f55e38d15402c5", size = 1113550, upload-time = "2025-08-07T13:42:37.467Z" },
@@ -431,6 +470,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/de/f28ced0a67749cac23fecb02b694f6473f47686dff6afaa211d186e2ef9c/greenlet-3.2.4-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:96378df1de302bc38e99c3a9aa311967b7dc80ced1dcc6f171e99842987882a2", size = 272305, upload-time = "2025-08-07T13:15:41.288Z" },
     { url = "https://files.pythonhosted.org/packages/09/16/2c3792cba130000bf2a31c5272999113f4764fd9d874fb257ff588ac779a/greenlet-3.2.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1ee8fae0519a337f2329cb78bd7a8e128ec0f881073d43f023c7b8d4831d5246", size = 632472, upload-time = "2025-08-07T13:42:55.044Z" },
     { url = "https://files.pythonhosted.org/packages/ae/8f/95d48d7e3d433e6dae5b1682e4292242a53f22df82e6d3dda81b1701a960/greenlet-3.2.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94abf90142c2a18151632371140b3dba4dee031633fe614cb592dbb6c9e17bc3", size = 644646, upload-time = "2025-08-07T13:45:26.523Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/5e/405965351aef8c76b8ef7ad370e5da58d57ef6068df197548b015464001a/greenlet-3.2.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:4d1378601b85e2e5171b99be8d2dc85f594c79967599328f95c1dc1a40f1c633", size = 640519, upload-time = "2025-08-07T13:53:13.928Z" },
     { url = "https://files.pythonhosted.org/packages/25/5d/382753b52006ce0218297ec1b628e048c4e64b155379331f25a7316eb749/greenlet-3.2.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0db5594dce18db94f7d1650d7489909b57afde4c580806b8d9203b6e79cdc079", size = 639707, upload-time = "2025-08-07T13:18:27.146Z" },
     { url = "https://files.pythonhosted.org/packages/1f/8e/abdd3f14d735b2929290a018ecf133c901be4874b858dd1c604b9319f064/greenlet-3.2.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2523e5246274f54fdadbce8494458a2ebdcdbc7b802318466ac5606d3cded1f8", size = 587684, upload-time = "2025-08-07T13:18:25.164Z" },
     { url = "https://files.pythonhosted.org/packages/5d/65/deb2a69c3e5996439b0176f6651e0052542bb6c8f8ec2e3fba97c9768805/greenlet-3.2.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1987de92fec508535687fb807a5cea1560f6196285a4cde35c100b8cd632cc52", size = 1116647, upload-time = "2025-08-07T13:42:38.655Z" },
@@ -441,6 +481,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
@@ -451,6 +492,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
     { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
     { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
@@ -461,6 +503,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
     { url = "https://files.pythonhosted.org/packages/c0/aa/687d6b12ffb505a4447567d1f3abea23bd20e73a5bed63871178e0831b7a/greenlet-3.2.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c17b6b34111ea72fc5a4e4beec9711d2226285f0386ea83477cbb97c30a3f3a5", size = 699218, upload-time = "2025-08-07T13:45:30.969Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
     { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },
@@ -469,6 +512,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/c0/93885c4106d2626bf51fdec377d6aef740dfa5c4877461889a7cf8e565cc/greenlet-3.2.4-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:b6a7c19cf0d2742d0809a4c05975db036fdff50cd294a93632d6a310bf9ac02c", size = 269859, upload-time = "2025-08-07T13:16:16.003Z" },
     { url = "https://files.pythonhosted.org/packages/4d/f5/33f05dc3ba10a02dedb1485870cf81c109227d3d3aa280f0e48486cac248/greenlet-3.2.4-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:27890167f55d2387576d1f41d9487ef171849ea0359ce1510ca6e06c8bece11d", size = 627610, upload-time = "2025-08-07T13:43:01.345Z" },
     { url = "https://files.pythonhosted.org/packages/b2/a7/9476decef51a0844195f99ed5dc611d212e9b3515512ecdf7321543a7225/greenlet-3.2.4-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:18d9260df2b5fbf41ae5139e1be4e796d99655f023a636cd0e11e6406cca7d58", size = 639417, upload-time = "2025-08-07T13:45:32.094Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/e0/849b9159cbb176f8c0af5caaff1faffdece7a8417fcc6fe1869770e33e21/greenlet-3.2.4-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:671df96c1f23c4a0d4077a325483c1503c96a1b7d9db26592ae770daa41233d4", size = 634751, upload-time = "2025-08-07T13:53:18.848Z" },
     { url = "https://files.pythonhosted.org/packages/5f/d3/844e714a9bbd39034144dca8b658dcd01839b72bb0ec7d8014e33e3705f0/greenlet-3.2.4-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:16458c245a38991aa19676900d48bd1a6f2ce3e16595051a4db9d012154e8433", size = 634020, upload-time = "2025-08-07T13:18:36.841Z" },
     { url = "https://files.pythonhosted.org/packages/6b/4c/f3de2a8de0e840ecb0253ad0dc7e2bb3747348e798ec7e397d783a3cb380/greenlet-3.2.4-cp39-cp39-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c9913f1a30e4526f432991f89ae263459b1c64d1608c0d22a5c79c287b3c70df", size = 582817, upload-time = "2025-08-07T13:18:35.48Z" },
     { url = "https://files.pythonhosted.org/packages/89/80/7332915adc766035c8980b161c2e5d50b2f941f453af232c164cff5e0aeb/greenlet-3.2.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:b90654e092f928f110e0007f572007c9727b5265f7632c2fa7415b4689351594", size = 1111985, upload-time = "2025-08-07T13:42:42.425Z" },
@@ -491,6 +535,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/32/6a/33d1702184d94106d3cdd7bfb788e19723206fce152e303473ca3b946c7b/greenlet-3.3.0-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:6f8496d434d5cb2dce025773ba5597f71f5410ae499d5dd9533e0653258cdb3d", size = 273658, upload-time = "2025-12-04T14:23:37.494Z" },
     { url = "https://files.pythonhosted.org/packages/d6/b7/2b5805bbf1907c26e434f4e448cd8b696a0b71725204fa21a211ff0c04a7/greenlet-3.3.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b96dc7eef78fd404e022e165ec55327f935b9b52ff355b067eb4a0267fc1cffb", size = 574810, upload-time = "2025-12-04T14:50:04.154Z" },
     { url = "https://files.pythonhosted.org/packages/94/38/343242ec12eddf3d8458c73f555c084359883d4ddc674240d9e61ec51fd6/greenlet-3.3.0-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:73631cd5cccbcfe63e3f9492aaa664d278fda0ce5c3d43aeda8e77317e38efbd", size = 586248, upload-time = "2025-12-04T14:57:39.35Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/d0/0ae86792fb212e4384041e0ef8e7bc66f59a54912ce407d26a966ed2914d/greenlet-3.3.0-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b299a0cb979f5d7197442dccc3aee67fce53500cd88951b7e6c35575701c980b", size = 597403, upload-time = "2025-12-04T15:07:10.831Z" },
     { url = "https://files.pythonhosted.org/packages/b6/a8/15d0aa26c0036a15d2659175af00954aaaa5d0d66ba538345bd88013b4d7/greenlet-3.3.0-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7dee147740789a4632cace364816046e43310b59ff8fb79833ab043aefa72fd5", size = 586910, upload-time = "2025-12-04T14:25:59.705Z" },
     { url = "https://files.pythonhosted.org/packages/e1/9b/68d5e3b7ccaba3907e5532cf8b9bf16f9ef5056a008f195a367db0ff32db/greenlet-3.3.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:39b28e339fc3c348427560494e28d8a6f3561c8d2bcf7d706e1c624ed8d822b9", size = 1547206, upload-time = "2025-12-04T15:04:21.027Z" },
     { url = "https://files.pythonhosted.org/packages/66/bd/e3086ccedc61e49f91e2cfb5ffad9d8d62e5dc85e512a6200f096875b60c/greenlet-3.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b3c374782c2935cc63b2a27ba8708471de4ad1abaa862ffdb1ef45a643ddbb7d", size = 1613359, upload-time = "2025-12-04T14:27:26.548Z" },
@@ -498,6 +543,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/cb/48e964c452ca2b92175a9b2dca037a553036cb053ba69e284650ce755f13/greenlet-3.3.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:e29f3018580e8412d6aaf5641bb7745d38c85228dacf51a73bd4e26ddf2a6a8e", size = 274908, upload-time = "2025-12-04T14:23:26.435Z" },
     { url = "https://files.pythonhosted.org/packages/28/da/38d7bff4d0277b594ec557f479d65272a893f1f2a716cad91efeb8680953/greenlet-3.3.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a687205fb22794e838f947e2194c0566d3812966b41c78709554aa883183fb62", size = 577113, upload-time = "2025-12-04T14:50:05.493Z" },
     { url = "https://files.pythonhosted.org/packages/3c/f2/89c5eb0faddc3ff014f1c04467d67dee0d1d334ab81fadbf3744847f8a8a/greenlet-3.3.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4243050a88ba61842186cb9e63c7dfa677ec146160b0efd73b855a3d9c7fcf32", size = 590338, upload-time = "2025-12-04T14:57:41.136Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d7/db0a5085035d05134f8c089643da2b44cc9b80647c39e93129c5ef170d8f/greenlet-3.3.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:670d0f94cd302d81796e37299bcd04b95d62403883b24225c6b5271466612f45", size = 601098, upload-time = "2025-12-04T15:07:11.898Z" },
     { url = "https://files.pythonhosted.org/packages/dc/a6/e959a127b630a58e23529972dbc868c107f9d583b5a9f878fb858c46bc1a/greenlet-3.3.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6cb3a8ec3db4a3b0eb8a3c25436c2d49e3505821802074969db017b87bc6a948", size = 590206, upload-time = "2025-12-04T14:26:01.254Z" },
     { url = "https://files.pythonhosted.org/packages/48/60/29035719feb91798693023608447283b266b12efc576ed013dd9442364bb/greenlet-3.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2de5a0b09eab81fc6a382791b995b1ccf2b172a9fec934747a7a23d2ff291794", size = 1550668, upload-time = "2025-12-04T15:04:22.439Z" },
     { url = "https://files.pythonhosted.org/packages/0a/5f/783a23754b691bfa86bd72c3033aa107490deac9b2ef190837b860996c9f/greenlet-3.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4449a736606bd30f27f8e1ff4678ee193bc47f6ca810d705981cfffd6ce0d8c5", size = 1615483, upload-time = "2025-12-04T14:27:28.083Z" },
@@ -505,6 +551,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/0a/a3871375c7b9727edaeeea994bfff7c63ff7804c9829c19309ba2e058807/greenlet-3.3.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:b01548f6e0b9e9784a2c99c5651e5dc89ffcbe870bc5fb2e5ef864e9cc6b5dcb", size = 276379, upload-time = "2025-12-04T14:23:30.498Z" },
     { url = "https://files.pythonhosted.org/packages/43/ab/7ebfe34dce8b87be0d11dae91acbf76f7b8246bf9d6b319c741f99fa59c6/greenlet-3.3.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:349345b770dc88f81506c6861d22a6ccd422207829d2c854ae2af8025af303e3", size = 597294, upload-time = "2025-12-04T14:50:06.847Z" },
     { url = "https://files.pythonhosted.org/packages/a4/39/f1c8da50024feecd0793dbd5e08f526809b8ab5609224a2da40aad3a7641/greenlet-3.3.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e8e18ed6995e9e2c0b4ed264d2cf89260ab3ac7e13555b8032b25a74c6d18655", size = 607742, upload-time = "2025-12-04T14:57:42.349Z" },
+    { url = "https://files.pythonhosted.org/packages/77/cb/43692bcd5f7a0da6ec0ec6d58ee7cddb606d055ce94a62ac9b1aa481e969/greenlet-3.3.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c024b1e5696626890038e34f76140ed1daf858e37496d33f2af57f06189e70d7", size = 622297, upload-time = "2025-12-04T15:07:13.552Z" },
     { url = "https://files.pythonhosted.org/packages/75/b0/6bde0b1011a60782108c01de5913c588cf51a839174538d266de15e4bf4d/greenlet-3.3.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:047ab3df20ede6a57c35c14bf5200fcf04039d50f908270d3f9a7a82064f543b", size = 609885, upload-time = "2025-12-04T14:26:02.368Z" },
     { url = "https://files.pythonhosted.org/packages/49/0e/49b46ac39f931f59f987b7cd9f34bfec8ef81d2a1e6e00682f55be5de9f4/greenlet-3.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2d9ad37fc657b1102ec880e637cccf20191581f75c64087a549e66c57e1ceb53", size = 1567424, upload-time = "2025-12-04T15:04:23.757Z" },
     { url = "https://files.pythonhosted.org/packages/05/f5/49a9ac2dff7f10091935def9165c90236d8f175afb27cbed38fb1d61ab6b/greenlet-3.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:83cd0e36932e0e7f36a64b732a6f60c2fc2df28c351bae79fbaf4f8092fe7614", size = 1636017, upload-time = "2025-12-04T14:27:29.688Z" },
@@ -512,6 +559,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/02/2f/28592176381b9ab2cafa12829ba7b472d177f3acc35d8fbcf3673d966fff/greenlet-3.3.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:a1e41a81c7e2825822f4e068c48cb2196002362619e2d70b148f20a831c00739", size = 275140, upload-time = "2025-12-04T14:23:01.282Z" },
     { url = "https://files.pythonhosted.org/packages/2c/80/fbe937bf81e9fca98c981fe499e59a3f45df2a04da0baa5c2be0dca0d329/greenlet-3.3.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9f515a47d02da4d30caaa85b69474cec77b7929b2e936ff7fb853d42f4bf8808", size = 599219, upload-time = "2025-12-04T14:50:08.309Z" },
     { url = "https://files.pythonhosted.org/packages/c2/ff/7c985128f0514271b8268476af89aee6866df5eec04ac17dcfbc676213df/greenlet-3.3.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7d2d9fd66bfadf230b385fdc90426fcd6eb64db54b40c495b72ac0feb5766c54", size = 610211, upload-time = "2025-12-04T14:57:43.968Z" },
+    { url = "https://files.pythonhosted.org/packages/79/07/c47a82d881319ec18a4510bb30463ed6891f2ad2c1901ed5ec23d3de351f/greenlet-3.3.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:30a6e28487a790417d036088b3bcb3f3ac7d8babaa7d0139edbaddebf3af9492", size = 624311, upload-time = "2025-12-04T15:07:14.697Z" },
     { url = "https://files.pythonhosted.org/packages/fd/8e/424b8c6e78bd9837d14ff7df01a9829fc883ba2ab4ea787d4f848435f23f/greenlet-3.3.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:087ea5e004437321508a8d6f20efc4cfec5e3c30118e1417ea96ed1d93950527", size = 612833, upload-time = "2025-12-04T14:26:03.669Z" },
     { url = "https://files.pythonhosted.org/packages/b5/ba/56699ff9b7c76ca12f1cdc27a886d0f81f2189c3455ff9f65246780f713d/greenlet-3.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ab97cf74045343f6c60a39913fa59710e4bd26a536ce7ab2397adf8b27e67c39", size = 1567256, upload-time = "2025-12-04T15:04:25.276Z" },
     { url = "https://files.pythonhosted.org/packages/1e/37/f31136132967982d698c71a281a8901daf1a8fbab935dce7c0cf15f942cc/greenlet-3.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5375d2e23184629112ca1ea89a53389dddbffcf417dad40125713d88eb5f96e8", size = 1636483, upload-time = "2025-12-04T14:27:30.804Z" },
@@ -519,6 +567,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/7c/f0a6d0ede2c7bf092d00bc83ad5bafb7e6ec9b4aab2fbdfa6f134dc73327/greenlet-3.3.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:60c2ef0f578afb3c8d92ea07ad327f9a062547137afe91f38408f08aacab667f", size = 275671, upload-time = "2025-12-04T14:23:05.267Z" },
     { url = "https://files.pythonhosted.org/packages/44/06/dac639ae1a50f5969d82d2e3dd9767d30d6dbdbab0e1a54010c8fe90263c/greenlet-3.3.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a5d554d0712ba1de0a6c94c640f7aeba3f85b3a6e1f2899c11c2c0428da9365", size = 646360, upload-time = "2025-12-04T14:50:10.026Z" },
     { url = "https://files.pythonhosted.org/packages/e0/94/0fb76fe6c5369fba9bf98529ada6f4c3a1adf19e406a47332245ef0eb357/greenlet-3.3.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3a898b1e9c5f7307ebbde4102908e6cbfcb9ea16284a3abe15cab996bee8b9b3", size = 658160, upload-time = "2025-12-04T14:57:45.41Z" },
+    { url = "https://files.pythonhosted.org/packages/93/79/d2c70cae6e823fac36c3bbc9077962105052b7ef81db2f01ec3b9bf17e2b/greenlet-3.3.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:dcd2bdbd444ff340e8d6bdf54d2f206ccddbb3ccfdcd3c25bf4afaa7b8f0cf45", size = 671388, upload-time = "2025-12-04T15:07:15.789Z" },
     { url = "https://files.pythonhosted.org/packages/b8/14/bab308fc2c1b5228c3224ec2bf928ce2e4d21d8046c161e44a2012b5203e/greenlet-3.3.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5773edda4dc00e173820722711d043799d3adb4f01731f40619e07ea2750b955", size = 660166, upload-time = "2025-12-04T14:26:05.099Z" },
     { url = "https://files.pythonhosted.org/packages/4b/d2/91465d39164eaa0085177f61983d80ffe746c5a1860f009811d498e7259c/greenlet-3.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ac0549373982b36d5fd5d30beb8a7a33ee541ff98d2b502714a09f1169f31b55", size = 1615193, upload-time = "2025-12-04T15:04:27.041Z" },
     { url = "https://files.pythonhosted.org/packages/42/1b/83d110a37044b92423084d52d5d5a3b3a73cafb51b547e6d7366ff62eff1/greenlet-3.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d198d2d977460358c3b3a4dc844f875d1adb33817f0613f663a656f463764ccc", size = 1683653, upload-time = "2025-12-04T14:27:32.366Z" },
@@ -526,6 +575,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/66/bd6317bc5932accf351fc19f177ffba53712a202f9df10587da8df257c7e/greenlet-3.3.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d6ed6f85fae6cdfdb9ce04c9bf7a08d666cfcfb914e7d006f44f840b46741931", size = 282638, upload-time = "2025-12-04T14:25:20.941Z" },
     { url = "https://files.pythonhosted.org/packages/30/cf/cc81cb030b40e738d6e69502ccbd0dd1bced0588e958f9e757945de24404/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9125050fcf24554e69c4cacb086b87b3b55dc395a8b3ebe6487b045b2614388", size = 651145, upload-time = "2025-12-04T14:50:11.039Z" },
     { url = "https://files.pythonhosted.org/packages/9c/ea/1020037b5ecfe95ca7df8d8549959baceb8186031da83d5ecceff8b08cd2/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:87e63ccfa13c0a0f6234ed0add552af24cc67dd886731f2261e46e241608bee3", size = 654236, upload-time = "2025-12-04T14:57:47.007Z" },
+    { url = "https://files.pythonhosted.org/packages/69/cc/1e4bae2e45ca2fa55299f4e85854606a78ecc37fead20d69322f96000504/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2662433acbca297c9153a4023fe2161c8dcfdcc91f10433171cf7e7d94ba2221", size = 662506, upload-time = "2025-12-04T15:07:16.906Z" },
     { url = "https://files.pythonhosted.org/packages/57/b9/f8025d71a6085c441a7eaff0fd928bbb275a6633773667023d19179fe815/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3c6e9b9c1527a78520357de498b0e709fb9e2f49c3a513afd5a249007261911b", size = 653783, upload-time = "2025-12-04T14:26:06.225Z" },
     { url = "https://files.pythonhosted.org/packages/f6/c7/876a8c7a7485d5d6b5c6821201d542ef28be645aa024cfe1145b35c120c1/greenlet-3.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:286d093f95ec98fdd92fcb955003b8a3d054b4e2cab3e2707a5039e7b50520fd", size = 1614857, upload-time = "2025-12-04T15:04:28.484Z" },
     { url = "https://files.pythonhosted.org/packages/4f/dc/041be1dff9f23dac5f48a43323cd0789cb798342011c19a248d9c9335536/greenlet-3.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c10513330af5b8ae16f023e8ddbfb486ab355d04467c4679c5cfe4659975dd9", size = 1676034, upload-time = "2025-12-04T14:27:33.531Z" },
@@ -676,6 +726,7 @@ dependencies = [
     { name = "alembic", version = "1.16.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "alembic", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "bcrypt" },
+    { name = "email-validator" },
     { name = "fastapi" },
     { name = "groq" },
     { name = "pydantic" },
@@ -701,6 +752,7 @@ dev = [
 requires-dist = [
     { name = "alembic", specifier = ">=1.13.1" },
     { name = "bcrypt", specifier = ">=4.1.1" },
+    { name = "email-validator", specifier = ">=2.3.0" },
     { name = "fastapi", specifier = ">=0.104.1" },
     { name = "groq", specifier = ">=0.4.2" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.25.2" },

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -7,10 +7,14 @@ interface LoginProps {
   onLoginSuccess: (token: string) => void;
 }
 
+type AuthMode = "login" | "signup" | "join";
+
 export default function Login({ onLoginSuccess }: LoginProps) {
   const navigate = useNavigate();
+  const [mode, setMode] = useState<AuthMode>("login");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [inviteCode, setInviteCode] = useState<string | null>(null);
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -18,14 +22,33 @@ export default function Login({ onLoginSuccess }: LoginProps) {
     setError(null);
 
     const form = new FormData(e.currentTarget);
-    const homeId = parseInt(form.get("homeId") as string);
-    const username = form.get("username") as string;
-    const password = form.get("password") as string;
 
     try {
-      const data = await api.auth.login(homeId, username, password);
+      let data;
+
+      if (mode === "signup") {
+        const email = form.get("email") as string;
+        const password = form.get("password") as string;
+        const homeName = form.get("homeName") as string;
+
+        data = await api.auth.signup(email, password, homeName);
+        setInviteCode(data.invite_code);
+      } else if (mode === "join") {
+        const inviteCode = form.get("inviteCode") as string;
+        const email = form.get("email") as string;
+        const username = form.get("username") as string;
+        const password = form.get("password") as string;
+
+        data = await api.auth.join(inviteCode, email, username, password);
+      } else {
+        // Login mode
+        const email = form.get("email") as string;
+        const password = form.get("password") as string;
+
+        data = await api.auth.loginEmail(email, password);
+      }
+
       localStorage.setItem("token", data.access_token);
-      localStorage.setItem("username", username);
       localStorage.setItem("userId", data.user_id.toString());
       localStorage.setItem("homeId", data.home_id.toString());
       onLoginSuccess(data.access_token);
@@ -38,122 +61,357 @@ export default function Login({ onLoginSuccess }: LoginProps) {
         navigate(nextUrl);
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Login failed");
+      setError(err instanceof Error ? err.message : `${mode} failed`);
     } finally {
       setLoading(false);
     }
   };
 
+  const getModeTitle = () => {
+    switch (mode) {
+      case "signup":
+        return "Create New Home";
+      case "join":
+        return "Join Existing Home";
+      default:
+        return "Enter Quest Log";
+    }
+  };
+
+  const getModeButton = () => {
+    switch (mode) {
+      case "signup":
+        return loading ? "Creating..." : "Create Home";
+      case "join":
+        return loading ? "Joining..." : "Join Home";
+      default:
+        return loading ? "Logging in..." : "Enter";
+    }
+  };
+
   return (
-    <form
-      onSubmit={handleSubmit}
-      className="p-8 md:p-10 max-w-md mx-auto shadow-lg"
-      style={{
-        backgroundColor: COLORS.darkPanel,
-        borderColor: COLORS.gold,
-        borderWidth: "4px",
-      }}
-    >
-      {/* Error */}
-      {error && (
-        <div
-          className="px-4 py-3 mb-6 rounded-sm font-serif text-sm"
+    <div className="p-8 md:p-10 max-w-md mx-auto">
+      {/* Mode Selector */}
+      <div className="flex mb-6 gap-2">
+        <button
+          onClick={() => setMode("login")}
+          className="flex-1 py-2 px-4 font-serif text-sm uppercase tracking-wider transition-all"
           style={{
-            backgroundColor: COLORS.redDarker,
-            borderColor: COLORS.redBorder,
-            borderWidth: "1px",
-            color: COLORS.redLight,
-          }}
-        >
-          {error}
-        </div>
-      )}
-
-      {/* Home ID Field */}
-      <div className="mb-6 md:mb-8">
-        <label
-          className="block text-sm uppercase tracking-wider mb-2 font-serif"
-          style={{ color: COLORS.gold }}
-        >
-          Home ID
-        </label>
-        <input
-          type="number"
-          name="homeId"
-          defaultValue="1"
-          required
-          className="w-full px-3 py-2 md:py-3 font-serif focus:outline-none focus:shadow-lg transition-all"
-          style={{
-            backgroundColor: COLORS.black,
+            backgroundColor: mode === "login" ? COLORS.gold : "transparent",
             borderColor: COLORS.gold,
             borderWidth: "2px",
-            color: COLORS.parchment,
+            color: mode === "login" ? COLORS.black : COLORS.gold,
           }}
-        />
-      </div>
-
-      {/* Username Field */}
-      <div className="mb-6 md:mb-8">
-        <label
-          className="block text-sm uppercase tracking-wider mb-2 font-serif"
-          style={{ color: COLORS.gold }}
         >
-          Username
-        </label>
-        <input
-          type="text"
-          name="username"
-          placeholder="alice"
-          required
-          className="w-full px-3 py-2 md:py-3 font-serif placeholder-opacity-50 focus:outline-none focus:shadow-lg transition-all"
+          Login
+        </button>
+        <button
+          onClick={() => setMode("signup")}
+          className="flex-1 py-2 px-4 font-serif text-sm uppercase tracking-wider transition-all"
           style={{
-            backgroundColor: COLORS.black,
+            backgroundColor: mode === "signup" ? COLORS.gold : "transparent",
             borderColor: COLORS.gold,
             borderWidth: "2px",
-            color: COLORS.parchment,
+            color: mode === "signup" ? COLORS.black : COLORS.gold,
           }}
-        />
-      </div>
-
-      {/* Password Field */}
-      <div className="mb-8 md:mb-10">
-        <label
-          className="block text-sm uppercase tracking-wider mb-2 font-serif"
-          style={{ color: COLORS.gold }}
         >
-          Password
-        </label>
-        <input
-          type="password"
-          name="password"
-          placeholder="••••••••"
-          required
-          className="w-full px-3 py-2 md:py-3 font-serif placeholder-opacity-50 focus:outline-none focus:shadow-lg transition-all"
+          Sign Up
+        </button>
+        <button
+          onClick={() => setMode("join")}
+          className="flex-1 py-2 px-4 font-serif text-sm uppercase tracking-wider transition-all"
           style={{
-            backgroundColor: COLORS.black,
+            backgroundColor: mode === "join" ? COLORS.gold : "transparent",
             borderColor: COLORS.gold,
             borderWidth: "2px",
-            color: COLORS.parchment,
+            color: mode === "join" ? COLORS.black : COLORS.gold,
           }}
-        />
+        >
+          Join
+        </button>
       </div>
 
-      {/* Submit Button */}
-      <button
-        type="submit"
-        disabled={loading}
-        className="w-full py-3 md:py-4 font-serif font-semibold text-sm uppercase tracking-wider transition-all duration-300 hover:shadow-lg"
+      {/* Form */}
+      <form
+        onSubmit={handleSubmit}
+        className="p-8 md:p-10 shadow-lg"
         style={{
-          backgroundColor: loading ? `rgba(212, 175, 55, 0.1)` : `rgba(212, 175, 55, 0.2)`,
+          backgroundColor: COLORS.darkPanel,
           borderColor: COLORS.gold,
-          borderWidth: "2px",
-          color: COLORS.gold,
-          cursor: loading ? "not-allowed" : "pointer",
-          opacity: loading ? 0.5 : 1,
+          borderWidth: "4px",
         }}
       >
-        {loading ? "Logging in..." : "Enter Quest Log"}
-      </button>
-    </form>
+        <h2
+          className="text-2xl font-serif font-bold mb-6 text-center uppercase tracking-wider"
+          style={{ color: COLORS.gold }}
+        >
+          {getModeTitle()}
+        </h2>
+
+        {/* Error */}
+        {error && (
+          <div
+            className="px-4 py-3 mb-6 rounded-sm font-serif text-sm"
+            style={{
+              backgroundColor: COLORS.redDarker,
+              borderColor: COLORS.redBorder,
+              borderWidth: "1px",
+              color: COLORS.redLight,
+            }}
+          >
+            {error}
+          </div>
+        )}
+
+        {/* Success message for signup with invite code */}
+        {inviteCode && mode === "signup" && (
+          <div
+            className="px-4 py-3 mb-6 rounded-sm font-serif text-sm"
+            style={{
+              backgroundColor: "rgba(34, 197, 94, 0.1)",
+              borderColor: "rgb(34, 197, 94)",
+              borderWidth: "1px",
+              color: "rgb(134, 239, 172)",
+            }}
+          >
+            <p className="font-bold mb-2">Home created successfully!</p>
+            <p className="mb-1">Share this invite code with others:</p>
+            <p className="font-mono text-base" style={{ color: COLORS.gold }}>
+              {inviteCode}
+            </p>
+          </div>
+        )}
+
+        {/* Signup Fields */}
+        {mode === "signup" && (
+          <>
+            <div className="mb-6 md:mb-8">
+              <label
+                className="block text-sm uppercase tracking-wider mb-2 font-serif"
+                style={{ color: COLORS.gold }}
+              >
+                Email Address
+              </label>
+              <input
+                type="email"
+                name="email"
+                placeholder="adventurer@realm.com"
+                required
+                className="w-full px-3 py-2 md:py-3 font-serif placeholder-opacity-50 focus:outline-none focus:shadow-lg transition-all"
+                style={{
+                  backgroundColor: COLORS.black,
+                  borderColor: COLORS.gold,
+                  borderWidth: "2px",
+                  color: COLORS.parchment,
+                }}
+              />
+            </div>
+
+            <div className="mb-6 md:mb-8">
+              <label
+                className="block text-sm uppercase tracking-wider mb-2 font-serif"
+                style={{ color: COLORS.gold }}
+              >
+                Home Name
+              </label>
+              <input
+                type="text"
+                name="homeName"
+                placeholder="The Dragon's Den"
+                required
+                className="w-full px-3 py-2 md:py-3 font-serif placeholder-opacity-50 focus:outline-none focus:shadow-lg transition-all"
+                style={{
+                  backgroundColor: COLORS.black,
+                  borderColor: COLORS.gold,
+                  borderWidth: "2px",
+                  color: COLORS.parchment,
+                }}
+              />
+            </div>
+
+            <div className="mb-8 md:mb-10">
+              <label
+                className="block text-sm uppercase tracking-wider mb-2 font-serif"
+                style={{ color: COLORS.gold }}
+              >
+                Password
+              </label>
+              <input
+                type="password"
+                name="password"
+                placeholder="••••••••"
+                required
+                className="w-full px-3 py-2 md:py-3 font-serif placeholder-opacity-50 focus:outline-none focus:shadow-lg transition-all"
+                style={{
+                  backgroundColor: COLORS.black,
+                  borderColor: COLORS.gold,
+                  borderWidth: "2px",
+                  color: COLORS.parchment,
+                }}
+              />
+            </div>
+          </>
+        )}
+
+        {/* Join Fields */}
+        {mode === "join" && (
+          <>
+            <div className="mb-6 md:mb-8">
+              <label
+                className="block text-sm uppercase tracking-wider mb-2 font-serif"
+                style={{ color: COLORS.gold }}
+              >
+                Invite Code
+              </label>
+              <input
+                type="text"
+                name="inviteCode"
+                placeholder="abc123xyz"
+                required
+                className="w-full px-3 py-2 md:py-3 font-mono placeholder-opacity-50 focus:outline-none focus:shadow-lg transition-all"
+                style={{
+                  backgroundColor: COLORS.black,
+                  borderColor: COLORS.gold,
+                  borderWidth: "2px",
+                  color: COLORS.parchment,
+                }}
+              />
+            </div>
+
+            <div className="mb-6 md:mb-8">
+              <label
+                className="block text-sm uppercase tracking-wider mb-2 font-serif"
+                style={{ color: COLORS.gold }}
+              >
+                Email Address
+              </label>
+              <input
+                type="email"
+                name="email"
+                placeholder="adventurer@realm.com"
+                required
+                className="w-full px-3 py-2 md:py-3 font-serif placeholder-opacity-50 focus:outline-none focus:shadow-lg transition-all"
+                style={{
+                  backgroundColor: COLORS.black,
+                  borderColor: COLORS.gold,
+                  borderWidth: "2px",
+                  color: COLORS.parchment,
+                }}
+              />
+            </div>
+
+            <div className="mb-6 md:mb-8">
+              <label
+                className="block text-sm uppercase tracking-wider mb-2 font-serif"
+                style={{ color: COLORS.gold }}
+              >
+                Display Name
+              </label>
+              <input
+                type="text"
+                name="username"
+                placeholder="DragonSlayer"
+                required
+                className="w-full px-3 py-2 md:py-3 font-serif placeholder-opacity-50 focus:outline-none focus:shadow-lg transition-all"
+                style={{
+                  backgroundColor: COLORS.black,
+                  borderColor: COLORS.gold,
+                  borderWidth: "2px",
+                  color: COLORS.parchment,
+                }}
+              />
+            </div>
+
+            <div className="mb-8 md:mb-10">
+              <label
+                className="block text-sm uppercase tracking-wider mb-2 font-serif"
+                style={{ color: COLORS.gold }}
+              >
+                Password
+              </label>
+              <input
+                type="password"
+                name="password"
+                placeholder="••••••••"
+                required
+                className="w-full px-3 py-2 md:py-3 font-serif placeholder-opacity-50 focus:outline-none focus:shadow-lg transition-all"
+                style={{
+                  backgroundColor: COLORS.black,
+                  borderColor: COLORS.gold,
+                  borderWidth: "2px",
+                  color: COLORS.parchment,
+                }}
+              />
+            </div>
+          </>
+        )}
+
+        {/* Login Fields */}
+        {mode === "login" && (
+          <>
+            <div className="mb-6 md:mb-8">
+              <label
+                className="block text-sm uppercase tracking-wider mb-2 font-serif"
+                style={{ color: COLORS.gold }}
+              >
+                Email Address
+              </label>
+              <input
+                type="email"
+                name="email"
+                placeholder="adventurer@realm.com"
+                required
+                className="w-full px-3 py-2 md:py-3 font-serif placeholder-opacity-50 focus:outline-none focus:shadow-lg transition-all"
+                style={{
+                  backgroundColor: COLORS.black,
+                  borderColor: COLORS.gold,
+                  borderWidth: "2px",
+                  color: COLORS.parchment,
+                }}
+              />
+            </div>
+
+            <div className="mb-8 md:mb-10">
+              <label
+                className="block text-sm uppercase tracking-wider mb-2 font-serif"
+                style={{ color: COLORS.gold }}
+              >
+                Password
+              </label>
+              <input
+                type="password"
+                name="password"
+                placeholder="••••••••"
+                required
+                className="w-full px-3 py-2 md:py-3 font-serif placeholder-opacity-50 focus:outline-none focus:shadow-lg transition-all"
+                style={{
+                  backgroundColor: COLORS.black,
+                  borderColor: COLORS.gold,
+                  borderWidth: "2px",
+                  color: COLORS.parchment,
+                }}
+              />
+            </div>
+          </>
+        )}
+
+        {/* Submit Button */}
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full py-3 md:py-4 font-serif font-semibold text-sm uppercase tracking-wider transition-all duration-300 hover:shadow-lg"
+          style={{
+            backgroundColor: loading ? `rgba(212, 175, 55, 0.1)` : `rgba(212, 175, 55, 0.2)`,
+            borderColor: COLORS.gold,
+            borderWidth: "2px",
+            color: COLORS.gold,
+            cursor: loading ? "not-allowed" : "pointer",
+            opacity: loading ? 0.5 : 1,
+          }}
+        >
+          {getModeButton()}
+        </button>
+      </form>
+    </div>
   );
 }

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -13,6 +13,8 @@ export default function Profile({ token }: ProfileProps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showAllQuests, setShowAllQuests] = useState(false);
+  const [homeInfo, setHomeInfo] = useState<{ invite_code: string; home_name: string } | null>(null);
+  const [copiedInvite, setCopiedInvite] = useState(false);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -25,6 +27,12 @@ export default function Profile({ token }: ProfileProps) {
         ]);
         setUserStats(stats);
         setQuests(questsData);
+
+        // Fetch home info after we have the user stats
+        if (stats.home_id) {
+          const homeData = await api.home.getInviteCode(stats.home_id, token);
+          setHomeInfo(homeData);
+        }
       } catch (err) {
         setError(err instanceof Error ? err.message : "Failed to load profile data");
       } finally {
@@ -180,6 +188,62 @@ export default function Profile({ token }: ProfileProps) {
           </div>
         </div>
       </div>
+
+      {/* Home Information Section */}
+      {homeInfo && (
+        <div
+          className="p-6 rounded-lg mb-8"
+          style={{
+            backgroundColor: COLORS.darkPanel,
+            borderColor: COLORS.gold,
+            borderWidth: "2px",
+          }}
+        >
+          <h3
+            className="text-xl font-serif font-bold mb-4 text-center"
+            style={{ color: COLORS.gold }}
+          >
+            Your Home
+          </h3>
+          <div className="text-center mb-6">
+            <p className="text-xs uppercase tracking-widest mb-1" style={{ color: COLORS.brown }}>
+              Home Name
+            </p>
+            <p className="text-2xl font-serif font-bold" style={{ color: COLORS.parchment }}>
+              {homeInfo.home_name}
+            </p>
+          </div>
+          <div className="text-center">
+            <p className="text-xs uppercase tracking-widest mb-2" style={{ color: COLORS.brown }}>
+              Invite Code
+            </p>
+            <div className="flex items-center justify-center gap-3 mb-2">
+              <p className="text-xl font-mono font-bold" style={{ color: COLORS.gold }}>
+                {homeInfo.invite_code}
+              </p>
+              <button
+                onClick={() => {
+                  navigator.clipboard.writeText(homeInfo.invite_code);
+                  setCopiedInvite(true);
+                  setTimeout(() => setCopiedInvite(false), 2000);
+                }}
+                className="px-3 py-1 text-xs font-serif uppercase tracking-wider transition-all"
+                style={{
+                  backgroundColor: copiedInvite ? COLORS.greenSuccess : "transparent",
+                  borderColor: copiedInvite ? COLORS.greenSuccess : COLORS.gold,
+                  borderWidth: "2px",
+                  color: copiedInvite ? COLORS.dark : COLORS.gold,
+                }}
+              >
+                {copiedInvite ? "Copied!" : "Copy"}
+              </button>
+            </div>
+            <p className="font-serif text-sm" style={{ color: COLORS.parchment, opacity: 0.7 }}>
+              Share this code with others to invite them to your home
+            </p>
+          </div>
+        </div>
+      )}
 
       {/* Achievements Section (Placeholder) */}
       <div

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -36,6 +36,54 @@ export const api = {
       if (!res.ok) throw new Error("Login failed");
       return res.json();
     },
+
+    loginEmail: async (email: string, password: string): Promise<LoginResponse> => {
+      const res = await fetch(`${API_URL}/auth/login-email`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password }),
+      });
+      if (!res.ok) {
+        const error = await res.json();
+        throw new Error(error.detail?.message || "Login failed");
+      }
+      return res.json();
+    },
+
+    signup: async (
+      email: string,
+      password: string,
+      homeName: string
+    ): Promise<LoginResponse & { invite_code: string }> => {
+      const res = await fetch(`${API_URL}/auth/signup`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password, home_name: homeName }),
+      });
+      if (!res.ok) {
+        const error = await res.json();
+        throw new Error(error.detail?.message || "Signup failed");
+      }
+      return res.json();
+    },
+
+    join: async (
+      inviteCode: string,
+      email: string,
+      username: string,
+      password: string
+    ): Promise<LoginResponse> => {
+      const res = await fetch(`${API_URL}/auth/join`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ invite_code: inviteCode, email, username, password }),
+      });
+      if (!res.ok) {
+        const error = await res.json();
+        throw new Error(error.detail?.message || "Failed to join home");
+      }
+      return res.json();
+    },
   },
 
   user: {
@@ -169,6 +217,16 @@ export const api = {
         headers: { Authorization: `Bearer ${token}` },
       });
       if (!res.ok) throw new Error("Failed to check bounty status");
+      return res.json();
+    },
+  },
+
+  home: {
+    getInviteCode: async (homeId: number, token: string): Promise<{ invite_code: string; home_name: string }> => {
+      const res = await fetch(`${API_URL}/homes/${homeId}/invite-code`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) throw new Error("Failed to fetch invite code");
       return res.json();
     },
   },


### PR DESCRIPTION
This commit implements a complete signup and authentication workflow:

Backend changes:
- Add email field to User model (globally unique, nullable for backward compatibility)
- Add email-validator dependency to pyproject.toml
- Create database migration for email field
- Add get_user_by_email CRUD function
- Create POST /api/auth/signup endpoint (email, password, home_name)
  - Creates new home with auto-generated invite code
  - Creates first user with email and username derived from email
  - Returns JWT token for immediate login
- Create POST /api/auth/login-email endpoint (email, password)
  - Authenticates user globally by email instead of home_id
- Create POST /api/auth/join endpoint (invite_code, email, username, password)
  - Allows users to join existing homes via invite code
- Add GET /api/homes/{home_id}/invite-code endpoint
  - Returns home's invite code and name for sharing

Frontend changes:
- Update Login component with three modes: Login, Signup, Join
  - Login: email + password (no home_id required)
  - Signup: email + password + home name
  - Join: invite code + email + username + password
- Add invite code display in signup success message
- Update Profile page to show home name and invite code
  - Add copy-to-clipboard functionality for invite code
- Update API service with new auth methods:
  - loginEmail, signup, join, home.getInviteCode

Architecture:
- Email is globally unique for login
- Username (display name) is unique within each home
- Invite codes are auto-generated on home creation
- Multi-use, revocable invite codes (simple v1)

Tested:
- Signup creates home and user successfully
- Login with email authenticates correctly
- Join with invite code adds user to existing home
- Invite code retrieval works for home members