### PR TITLE
Implement quest corruption system with optional user-set deadlines

### DIFF
--- a/backend/app/models/quest.py
+++ b/backend/app/models/quest.py
@@ -86,6 +86,11 @@ class Quest(SQLModel, table=True):
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     completed_at: Optional[datetime] = None
 
+    # Corruption system fields
+    quest_type: str = Field(default="standard")  # standard, bounty, corrupted
+    due_date: Optional[datetime] = None  # when quest should be completed (optional, user-set)
+    corrupted_at: Optional[datetime] = None  # when quest became corrupted
+
     # Relationships
     home: "Home" = Relationship(back_populates="quests")
     user: "User" = Relationship(back_populates="quests")
@@ -102,6 +107,9 @@ class QuestRead(SQLModel):
     completed: bool
     created_at: datetime
     completed_at: Optional[datetime]
+    quest_type: str
+    due_date: Optional[datetime]
+    corrupted_at: Optional[datetime]
     # Include template data for convenience
     template: QuestTemplateRead
 
@@ -110,9 +118,12 @@ class QuestCreate(SQLModel):
     """Schema for creating a quest from a template"""
 
     quest_template_id: int
+    due_date: Optional[datetime] = None  # optional user-set deadline
 
 
 class QuestUpdate(SQLModel):
     """Schema for updating a quest"""
 
     completed: Optional[bool] = None
+    quest_type: Optional[str] = None
+    due_date: Optional[datetime] = None

--- a/backend/migrations/versions/add_corruption_system_fields.py
+++ b/backend/migrations/versions/add_corruption_system_fields.py
@@ -1,0 +1,30 @@
+"""Add corruption system fields to quest table
+
+Revision ID: add_corruption_002
+Revises: add_quest_type_001
+Create Date: 2026-01-13
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "add_corruption_002"
+down_revision = "add_tags_001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add corruption system fields to quest table
+    op.add_column("quest", sa.Column("quest_type", sa.String(), nullable=False, server_default="standard"))
+    op.add_column("quest", sa.Column("due_date", sa.DateTime(), nullable=True))
+    op.add_column("quest", sa.Column("corrupted_at", sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    # Remove corruption system fields
+    op.drop_column("quest", "corrupted_at")
+    op.drop_column("quest", "due_date")
+    op.drop_column("quest", "quest_type")

--- a/frontend/src/components/CreateQuestForm.tsx
+++ b/frontend/src/components/CreateQuestForm.tsx
@@ -16,6 +16,7 @@ interface CreateQuestFormProps {
 export default function CreateQuestForm({ token, onQuestCreated, onClose }: CreateQuestFormProps) {
   const [title, setTitle] = useState("");
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [dueDate, setDueDate] = useState<string>("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [skipAI, setSkipAI] = useState(false);
@@ -57,6 +58,7 @@ export default function CreateQuestForm({ token, onQuestCreated, onClose }: Crea
       await api.quests.create(
         {
           quest_template_id: newTemplate.id,
+          ...(dueDate && { due_date: new Date(dueDate).toISOString() }),
         },
         token,
         userId
@@ -67,6 +69,7 @@ export default function CreateQuestForm({ token, onQuestCreated, onClose }: Crea
       setShowEditModal(true);
       setTitle("");
       setSelectedTags([]);
+      setDueDate("");
       setSkipAI(false);
       // Note: onQuestCreated will be called after edit modal saves
     } catch (err) {
@@ -218,6 +221,33 @@ export default function CreateQuestForm({ token, onQuestCreated, onClose }: Crea
                   </button>
                 ))}
               </div>
+            </div>
+
+            {/* Due Date Field */}
+            <div className="mb-6">
+              <label
+                className="block text-sm uppercase tracking-wider mb-2 font-serif"
+                style={{ color: COLORS.gold }}
+              >
+                Due Date (Optional)
+              </label>
+              <input
+                type="datetime-local"
+                value={dueDate}
+                onChange={e => setDueDate(e.target.value)}
+                className="w-full px-3 py-2 font-serif focus:outline-none focus:shadow-lg transition-all"
+                style={{
+                  backgroundColor: COLORS.black,
+                  borderColor: COLORS.gold,
+                  borderWidth: "2px",
+                  color: COLORS.parchment,
+                  colorScheme: "dark",
+                }}
+                disabled={loading}
+              />
+              <p className="text-xs mt-1 font-serif italic" style={{ color: COLORS.parchment }}>
+                Quest will become corrupted (1.5x rewards) if not completed by this time
+              </p>
             </div>
 
             {/* Skip AI Scribe Checkbox */}

--- a/frontend/src/components/QuestCard.tsx
+++ b/frontend/src/components/QuestCard.tsx
@@ -41,7 +41,23 @@ interface QuestCardProps {
 }
 
 export default function QuestCard({ quest, onComplete, isDailyBounty = false }: QuestCardProps) {
-  const typeStyles = getQuestTypeStyles(quest.template.quest_type);
+  const typeStyles = getQuestTypeStyles(quest.quest_type);
+  const isCorrupted = quest.quest_type === "corrupted";
+
+  // Format due date for display
+  const formatDueDate = (dueDate: string | null) => {
+    if (!dueDate) return null;
+    const date = new Date(dueDate);
+    const now = new Date();
+    const diff = date.getTime() - now.getTime();
+    const hours = Math.floor(diff / (1000 * 60 * 60));
+    const days = Math.floor(hours / 24);
+
+    if (diff < 0) return "Overdue";
+    if (days > 0) return `${days} day${days > 1 ? "s" : ""} left`;
+    if (hours > 0) return `${hours} hour${hours > 1 ? "s" : ""} left`;
+    return "Due soon";
+  };
 
   return (
     <div
@@ -56,15 +72,15 @@ export default function QuestCard({ quest, onComplete, isDailyBounty = false }: 
       <div className="absolute top-3 right-4 text-2xl opacity-20">⚔</div>
 
       {/* Quest Type Badge */}
-      <div className="absolute top-4 left-4 flex gap-2">
+      <div className="absolute top-4 left-4 flex gap-2 flex-wrap">
         <span
-          className="px-2 py-1 rounded text-xs uppercase font-serif font-bold"
+          className={`px-2 py-1 rounded text-xs uppercase font-serif font-bold ${isCorrupted ? "animate-pulse" : ""}`}
           style={{
             backgroundColor: typeStyles.badgeBg,
             color: typeStyles.badgeColor,
           }}
         >
-          {quest.template.quest_type}
+          {quest.quest_type}
         </span>
         {isDailyBounty && (
           <span
@@ -75,6 +91,29 @@ export default function QuestCard({ quest, onComplete, isDailyBounty = false }: 
             }}
           >
             2x Bounty
+          </span>
+        )}
+        {isCorrupted && (
+          <span
+            className="px-2 py-1 rounded text-xs uppercase font-serif font-bold"
+            style={{
+              backgroundColor: "rgba(139, 58, 58, 0.3)",
+              color: "#ff8080",
+            }}
+          >
+            1.5x Rewards
+          </span>
+        )}
+        {quest.due_date && !quest.completed && (
+          <span
+            className="px-2 py-1 rounded text-xs font-serif font-bold"
+            style={{
+              backgroundColor: isCorrupted ? "rgba(139, 58, 58, 0.2)" : "rgba(255, 165, 0, 0.2)",
+              color: isCorrupted ? "#ff6b6b" : "#ffa500",
+              border: `1px solid ${isCorrupted ? "#ff6b6b" : "#ffa500"}`,
+            }}
+          >
+            📅 {formatDueDate(quest.due_date)}
           </span>
         )}
       </div>
@@ -132,6 +171,11 @@ export default function QuestCard({ quest, onComplete, isDailyBounty = false }: 
           </div>
           <div className="text-2xl md:text-3xl font-serif font-bold" style={{ color: COLORS.gold }}>
             {quest.template.xp_reward || 0}
+            {isCorrupted && !quest.completed && (
+              <span className="text-sm ml-2" style={{ color: "#ff8080" }}>
+                (x1.5)
+              </span>
+            )}
           </div>
         </div>
         <div className="text-center flex-1">
@@ -143,6 +187,11 @@ export default function QuestCard({ quest, onComplete, isDailyBounty = false }: 
           </div>
           <div className="text-2xl md:text-3xl font-serif font-bold" style={{ color: COLORS.gold }}>
             {quest.template.gold_reward || 0}
+            {isCorrupted && !quest.completed && (
+              <span className="text-sm ml-2" style={{ color: "#ff8080" }}>
+                (x1.5)
+              </span>
+            )}
           </div>
         </div>
         <div className="text-center flex-1">

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -24,6 +24,9 @@ export interface Quest {
   completed: boolean;
   created_at: string;
   completed_at: string | null;
+  quest_type: string;
+  due_date: string | null;
+  corrupted_at: string | null;
   template: QuestTemplate;
 }
 
@@ -58,6 +61,7 @@ export interface QuestCompleteResponse {
     xp: number;
     gold: number;
     is_daily_bounty: boolean;
+    is_corrupted: boolean;
     multiplier: number;
   };
 }
@@ -91,4 +95,5 @@ export interface QuestTemplateUpdateRequest {
 
 export interface QuestCreateRequest {
   quest_template_id: number;
+  due_date?: string | null;
 }


### PR DESCRIPTION
This commit implements the corruption system as described in the design
decisions document, allowing quests to become "corrupted" when they are
not completed by their deadline.

Backend Changes:
- Add corruption fields to Quest model: quest_type, due_date, corrupted_at
- Add check_and_corrupt_overdue_quests() function to detect and corrupt overdue quests
- Automatically check for overdue quests when fetching quest list
- Add /api/quests/check-corruption endpoint for manual triggers
- Apply 1.5x reward multiplier for corrupted quests (vs 2x for daily bounties)
- Update quest completion logic to show is_corrupted status

Frontend Changes:
- Add optional due_date field to quest creation form with datetime picker
- Display due date countdown and corruption status in quest cards
- Add visual styling for corrupted quests (red theme with pulsing animation)
- Show 1.5x multiplier indicator on corrupted quest rewards
- Update TypeScript interfaces to include new corruption fields

Database Migration:
- Add migration to add quest_type, due_date, and corrupted_at to quest table

Key Features:
- Deadlines are optional and user-set only (low friction)
- Corrupted quests are worth 1.5x normal rewards
- Visual distinction with pulsing red borders and badges
- Automatic corruption checking on quest list fetch
- Manual corruption check endpoint for cron jobs