### PR TITLE
Add session-start hook and pre-commit instructions

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Session start hook for Claude Code
+# Ensures pre-commit hooks are installed and ready to use
+
+set -e
+
+echo "🔧 Setting up pre-commit hooks..."
+
+# Install pre-commit if not already installed
+if ! command -v pre-commit &> /dev/null; then
+    echo "📦 Installing pre-commit..."
+    uv tool install pre-commit
+fi
+
+# Install git hooks
+echo "🪝 Installing git hooks..."
+pre-commit install
+
+echo "✅ Pre-commit hooks ready!"

--- a/claude.md
+++ b/claude.md
@@ -88,6 +88,12 @@ pre-commit install
 pre-commit run --all-files
 ```
 
+**IMPORTANT for Claude Code sessions:**
+Before committing any changes, ALWAYS run the appropriate formatters:
+- **Backend changes**: `cd backend && uv run ruff format . && uv run ruff check --fix .`
+- **Frontend changes**: `cd frontend && bun run format`
+- **Or run all hooks**: `pre-commit run --all-files`
+
 ### Manual Linting
 
 **Backend**:


### PR DESCRIPTION
- Create .claude/hooks/session-start.sh to auto-install pre-commit
- Update claude.md with explicit pre-commit formatting instructions
- Ensures ruff and prettier hooks run properly in Claude Code sessions

This addresses the issue where pre-commit hooks weren't being applied
when creating PRs via Claude Code on the web.