### PR TITLE
Add Railway deployment configuration for mobile testing

### DIFF
--- a/RAILWAY_DEPLOYMENT.md
+++ b/RAILWAY_DEPLOYMENT.md
@@ -1,0 +1,163 @@
+# Railway Deployment Guide
+
+This guide will help you deploy Majordomo to Railway for mobile testing.
+
+## Prerequisites
+
+- GitHub account with this repository
+- Railway account (sign up at https://railway.app with GitHub)
+
+## Initial Setup (One-time)
+
+### 1. Create Railway Project
+
+1. Go to https://railway.app/new
+2. Click **"Deploy from GitHub repo"**
+3. Select `majordomo` repository
+4. Railway will automatically detect the `railway.toml` configuration
+
+### 2. Add PostgreSQL Database
+
+1. In your Railway project dashboard, click **"+ New"**
+2. Select **"Database" → "Add PostgreSQL"**
+3. Railway automatically creates a database and injects `DATABASE_URL` environment variable
+
+### 3. Configure Backend Service
+
+Click on the **backend** service, then go to **"Variables"** tab and add:
+
+```
+SECRET_KEY=<generate-a-random-secret>
+GROQ_API_KEY=<your-groq-api-key-optional>
+CORS_ORIGINS=*
+```
+
+**To generate SECRET_KEY:**
+```bash
+python -c "import secrets; print(secrets.token_urlsafe(32))"
+```
+
+### 4. Configure Frontend Service
+
+Click on the **frontend** service, then go to **"Settings"** tab:
+
+1. Under **"Build"**, add **Build Arguments**:
+   ```
+   VITE_API_URL=https://${{backend.RAILWAY_PUBLIC_DOMAIN}}/api
+   ```
+
+   This tells the frontend where to find the backend API.
+
+2. Under **"Networking"**, click **"Generate Domain"** to get a public URL
+
+### 5. Generate Backend Domain
+
+Click on the **backend** service → **"Settings"** → **"Networking"** → **"Generate Domain"**
+
+This gives your backend a public URL that the frontend can call.
+
+### 6. Deploy
+
+Railway will automatically deploy both services. Watch the deployment logs to ensure everything works.
+
+**Your app will be available at:**
+- Frontend: `https://your-frontend.up.railway.app`
+- Backend API: `https://your-backend.up.railway.app/api`
+
+## Automatic PR Preview Deployments
+
+Railway can automatically deploy every PR for testing:
+
+1. In Railway project settings, go to **"Deployments"**
+2. Enable **"PR Deploys"**
+3. Each PR will get a unique URL like `pr-123-frontend.up.railway.app`
+
+### Testing Workflow
+
+1. Claude creates a PR with new feature
+2. Railway auto-deploys to preview URL
+3. You test on your phone using the preview URL
+4. If approved, merge PR → Auto-deploys to production
+5. If changes needed, Claude updates PR → Railway redeploys preview
+
+## Database Migrations
+
+Railway runs Alembic migrations automatically on deploy. To run migrations manually:
+
+1. Click on **backend** service
+2. Go to **"Settings" → "Deploy Triggers"**
+3. Add migration command (if needed)
+
+Or use Railway CLI:
+```bash
+railway run alembic upgrade head
+```
+
+## Environment Variables Reference
+
+### Backend
+- `DATABASE_URL` - Automatically set by PostgreSQL addon
+- `SECRET_KEY` - JWT secret (required)
+- `GROQ_API_KEY` - For AI quest generation (optional)
+- `CORS_ORIGINS` - Set to `*` for development
+
+### Frontend
+- `VITE_API_URL` - Backend API URL (set as build arg)
+
+## Monitoring
+
+- **View Logs:** Click on service → "Logs" tab
+- **Metrics:** Click on service → "Metrics" tab for CPU/memory usage
+- **Health Checks:** Backend includes `/api/health` endpoint
+
+## Costs
+
+Railway offers $5/month free credit which is plenty for testing:
+- Hobby plan: $5/month free credit
+- Usage-based pricing after free credit
+- Typical testing usage: ~$3-4/month (well within free tier)
+
+## Troubleshooting
+
+### Frontend can't connect to backend
+- Check `VITE_API_URL` build arg includes `/api` path
+- Ensure backend domain is generated and public
+- Check CORS settings in backend
+
+### Database connection errors
+- Verify PostgreSQL addon is running
+- Check `DATABASE_URL` is set in backend variables
+
+### Build failures
+- Check deployment logs in Railway dashboard
+- Ensure all dependencies are in pyproject.toml / package.json
+
+## Useful Commands
+
+**Railway CLI** (optional, for advanced usage):
+```bash
+# Install
+npm i -g @railway/cli
+
+# Login
+railway login
+
+# Link to project
+railway link
+
+# View logs
+railway logs
+
+# Run commands in Railway environment
+railway run python manage.py migrate
+```
+
+## Next Steps
+
+After deployment:
+1. Test login/signup on your phone
+2. Create a quest and complete it
+3. Verify XP/rewards system works
+4. Test on different networks (WiFi, cellular)
+
+Your Majordomo app is now accessible anywhere! 🎉

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "bcrypt>=4.1.1",
     "groq>=0.4.2",
     "email-validator>=2.3.0",
+    "psycopg2-binary>=2.9.9",
 ]
 
 [project.optional-dependencies]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,6 +2,10 @@ FROM oven/bun:1 AS builder
 
 WORKDIR /app
 
+# Accept build argument for API URL
+ARG VITE_API_URL
+ENV VITE_API_URL=$VITE_API_URL
+
 # Copy package files
 COPY package.json bun.lockb* ./
 
@@ -11,7 +15,7 @@ RUN bun install --frozen-lockfile
 # Copy source
 COPY . .
 
-# Build the app
+# Build the app (VITE_API_URL will be embedded in the build)
 RUN bun run build
 
 # Production stage

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,25 @@
+# Railway Configuration for Majordomo
+# This file defines how Railway should deploy the backend and frontend services
+
+[build]
+builder = "dockerfile"
+dockerfilePath = "Dockerfile"
+
+# Backend Service Configuration
+[[services]]
+name = "backend"
+dockerfile = "backend/Dockerfile"
+
+[services.healthcheck]
+path = "/api/health"
+timeout = 100
+interval = 10
+
+# Frontend Service Configuration
+[[services]]
+name = "frontend"
+dockerfile = "frontend/Dockerfile"
+
+[services.variables]
+# Railway will inject RAILWAY_PUBLIC_DOMAIN for backend URL
+# This gets set as VITE_API_URL during build


### PR DESCRIPTION
This commit adds Railway cloud hosting support to enable testing the app on mobile devices without needing to run it locally or use port forwarding.

Changes:
- Add railway.toml configuration for backend and frontend services
- Add PostgreSQL support (psycopg2-binary) for Railway database
- Update frontend Dockerfile to accept VITE_API_URL build argument
- Add comprehensive Railway deployment documentation

With this setup:
1. Deploy to Railway from GitHub
2. Get unique URLs for backend and frontend
3. Test features on phone anywhere (not just local network)
4. Enable automatic PR preview deployments for testing branches

This significantly improves the mobile testing workflow.