### PR TITLE
docs: establish canonical architecture and API contract governance

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -148,6 +148,12 @@ Health check: `GET /` or `GET /health`
 
 Authentication: JWT tokens via `/api/auth/login`
 
+## Documentation Source of Truth
+
+- Canonical architecture snapshot: `docs/current-architecture.md`
+- API contract governance: `docs/api-contract-governance.md`
+- Runtime behavior and OpenAPI always override stale notes
+
 ## See Also
 
 - `backend/claude.md` - Backend architecture details

--- a/docs/api-contract-governance.md
+++ b/docs/api-contract-governance.md
@@ -1,0 +1,54 @@
+# API Contract Governance
+
+## Goal
+
+Define one API source of truth and remove frontend/backend documentation drift.
+
+## Source of Truth
+
+- **OpenAPI schema served by backend is authoritative**.
+- Canonical endpoint/schema view: `GET /openapi.json` from the running API.
+
+## Contract Workflow
+
+1. Make backend route/schema changes.
+2. Run backend tests.
+3. Verify OpenAPI reflects intended contract.
+4. Update frontend API layer/types from OpenAPI.
+5. Validate frontend builds and key flows.
+
+## Change Policy
+
+### Non-breaking changes
+
+Allowed in normal feature work:
+
+- Additive response fields
+- New optional request fields
+- New endpoints
+
+### Breaking changes
+
+Require explicit coordination:
+
+- Renamed/removed endpoints
+- Renamed/removed required fields
+- Changed semantics for existing fields
+
+For breaking changes:
+
+- Document migration notes in PR
+- Update all consumers in same branch before merge
+
+## PR Checklist (API-affecting work)
+
+- [ ] Backend tests pass
+- [ ] OpenAPI schema reviewed
+- [ ] Frontend API client/types updated (or no frontend impact)
+- [ ] Error code behavior unchanged or documented
+- [ ] `docs/current-architecture.md` updated if system behavior changed
+
+## Short-Term Plan
+
+- Keep using current handwritten frontend API layer.
+- In a follow-up, add OpenAPI-driven type generation for frontend client types.

--- a/docs/current-architecture.md
+++ b/docs/current-architecture.md
@@ -1,0 +1,55 @@
+# Current Architecture & Source of Truth
+
+## Purpose
+
+This document is the canonical snapshot of Majordomo's current architecture and implementation status.
+
+Use this file for onboarding and planning. If another document conflicts with this one, treat this file as authoritative unless code/API behavior proves otherwise.
+
+## Canonical Sources (Priority Order)
+
+1. **Runtime behavior + tests** (actual backend/frontend code and passing test suite)
+2. **OpenAPI schema from running backend** (`/openapi.json`)
+3. **This document** (`docs/current-architecture.md`)
+4. Supporting design/planning notes
+
+## System Overview
+
+- **Backend:** FastAPI + SQLModel + SQLite + JWT auth
+- **Frontend:** React + Vite + TypeScript + Tailwind + Framer Motion
+- **Primary goal:** self-hosted, mobile-first, family-friendly gamified household quest system
+
+## Gameplay Systems (Current)
+
+- Quest templates and quest instances
+- Daily bounty rotation
+- Corruption/debuff mechanics for overdue quests
+- Reward marketplace with consumables
+- Achievement criteria and unlock flow
+- NFC trigger route for quick quest completion
+
+## Documentation Status
+
+### Canonical / Keep Updated
+
+- `docs/current-architecture.md` (this file)
+- `docs/api-contract-governance.md`
+- `claude.md` (high-level quickstart and structure)
+
+### Contextual / May Reflect Earlier Phases
+
+These files remain valuable for background context, but may include phase-specific assumptions:
+
+- `QUEST_SYSTEM_NOTES.md`
+- `backend/achievements.md`
+- `backend/validation.md`
+- `backend/error_codes.md`
+- `frontend/FONT_DEBUG_*`
+
+When in doubt, verify against code and OpenAPI.
+
+## Maintenance Rules
+
+- Update this file whenever architecture, core flow, or major endpoint patterns change.
+- If you add or change APIs, update `docs/api-contract-governance.md` and regenerate/verify OpenAPI contract.
+- Keep this file concise: architecture and truth sources only.


### PR DESCRIPTION
### Motivation

- Reduce documentation drift by declaring a single canonical architecture snapshot and a clear API contract workflow. 
- Ensure the OpenAPI runtime schema is treated as the authoritative API source to keep frontend and backend in sync.

### Description

- Add `docs/current-architecture.md` to capture the canonical architecture, precedence rules (runtime/tests/OpenAPI > docs), system overview, and maintenance rules. 
- Add `docs/api-contract-governance.md` to declare the OpenAPI schema (`GET /openapi.json`) as the API source of truth and to define the backend→OpenAPI→frontend workflow, breaking-change policy, and an API PR checklist. 
- Update `claude.md` to reference the new `docs/current-architecture.md` and `docs/api-contract-governance.md` as the documentation source of truth.

### Testing

- Ran `git diff --check` with no issues reported. 
- Ran `git status --short --branch` to verify workspace changes were staged as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dd1dea9c4832d93ca71c0563c9a31)