### PR TITLE
Fix home deletion with starter rewards

### DIFF
--- a/backend/app/crud/home.py
+++ b/backend/app/crud/home.py
@@ -2,10 +2,15 @@ import secrets
 from typing import Optional
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-from sqlmodel import Session, select
+from sqlmodel import Session, delete, select
 
 from app.crud import reward as crud_reward
+from app.models.achievement import Achievement, UserAchievement
+from app.models.daily_bounty import DailyBounty
 from app.models.home import Home, HomeCreate
+from app.models.quest import Quest, QuestTemplate, UserTemplateSubscription
+from app.models.reward import Reward, UserRewardClaim
+from app.models.user import User
 
 
 def generate_invite_code() -> str:
@@ -66,6 +71,33 @@ def delete_home(db: Session, home_id: int) -> bool:
     db_home = get_home(db, home_id)
     if not db_home:
         return False
+
+    user_ids = db.exec(select(User.id).where(User.home_id == home_id)).all()
+    template_ids = db.exec(select(QuestTemplate.id).where(QuestTemplate.home_id == home_id)).all()
+    reward_ids = db.exec(select(Reward.id).where(Reward.home_id == home_id)).all()
+    achievement_ids = db.exec(select(Achievement.id).where(Achievement.home_id == home_id)).all()
+
+    db.exec(delete(DailyBounty).where(DailyBounty.home_id == home_id))
+    db.exec(delete(Quest).where(Quest.home_id == home_id))
+
+    if reward_ids:
+        db.exec(delete(UserRewardClaim).where(UserRewardClaim.reward_id.in_(reward_ids)))
+
+    if achievement_ids:
+        db.exec(delete(UserAchievement).where(UserAchievement.achievement_id.in_(achievement_ids)))
+
+    if template_ids:
+        db.exec(delete(UserTemplateSubscription).where(UserTemplateSubscription.quest_template_id.in_(template_ids)))
+
+    db.exec(delete(Reward).where(Reward.home_id == home_id))
+    db.exec(delete(QuestTemplate).where(QuestTemplate.home_id == home_id))
+    db.exec(delete(Achievement).where(Achievement.home_id == home_id))
+
+    if user_ids:
+        db.exec(delete(UserRewardClaim).where(UserRewardClaim.user_id.in_(user_ids)))
+        db.exec(delete(UserAchievement).where(UserAchievement.user_id.in_(user_ids)))
+        db.exec(delete(UserTemplateSubscription).where(UserTemplateSubscription.user_id.in_(user_ids)))
+        db.exec(delete(User).where(User.id.in_(user_ids)))
 
     db.delete(db_home)
     db.commit()

--- a/backend/tests/test_rewards.py
+++ b/backend/tests/test_rewards.py
@@ -35,7 +35,7 @@ def test_get_reward(client: TestClient):
 
 
 def test_get_home_rewards(client: TestClient):
-    """Test retrieving all rewards in a home"""
+    """Test retrieving all rewards in a home, including starter consumables"""
     # Create home
     home_response = client.post("/api/homes", json={"name": "Test Home"})
     home_id = home_response.json()["id"]
@@ -47,7 +47,8 @@ def test_get_home_rewards(client: TestClient):
     # Get rewards
     response = client.get(f"/api/rewards?home_id={home_id}")
     assert response.status_code == 200
-    assert len(response.json()) == 2
+    reward_names = {reward["name"] for reward in response.json()}
+    assert reward_names == {"Heroic Elixir", "Purification Shield", "Reward 1", "Reward 2"}
 
 
 def test_get_home_rewards_multiple(client: TestClient):


### PR DESCRIPTION
## Summary
- make `delete_home` clean up dependent home-scoped rows before removing the home
- update the home rewards test to account for starter consumables that are now provisioned on home creation

## Why
`main` currently has two backend test failures:
- `tests/test_homes.py::test_delete_home`
- `tests/test_rewards.py::test_get_home_rewards`

Deleting a home was failing because starter rewards introduced non-null dependent rows, and the reward test still assumed an empty shop after home creation.

## Verification
- `uv run pytest tests/test_homes.py::test_delete_home tests/test_rewards.py::test_get_home_rewards`
- `uv run pytest`
