### PR TITLE
Fix profile quest history filtering

### DIFF
--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -9,7 +9,7 @@ import { LAYERS } from "../constants/layers";
 import { copyTextToClipboard } from "../utils/clipboard";
 
 export default function Profile() {
-  const { token } = useAuth();
+  const { token, userId } = useAuth();
   const [userStats, setUserStats] = useState<User | null>(null);
   const [quests, setQuests] = useState<Quest[]>([]);
   const [loading, setLoading] = useState(true);
@@ -23,7 +23,7 @@ export default function Profile() {
 
   useEffect(() => {
     const fetchData = async () => {
-      if (!token) {
+      if (!token || userId === null) {
         setError("Not authenticated");
         setLoading(false);
         return;
@@ -34,7 +34,7 @@ export default function Profile() {
       try {
         const [stats, questsData, achievementsData, userAchievementsData] = await Promise.all([
           api.user.getStats(token),
-          api.quests.getAll(token),
+          api.quests.getByUser(userId, token, true),
           api.achievements.getAll(token),
           api.achievements.getMyAchievements(token),
         ]);
@@ -56,7 +56,7 @@ export default function Profile() {
     };
 
     fetchData();
-  }, [token]);
+  }, [token, userId]);
 
   const completedQuests = useMemo(() => quests.filter((q) => q.completed), [quests]);
   const sortedCompletedQuests = useMemo(

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -165,6 +165,24 @@ export const api = {
     getAll: async (token: string): Promise<Quest[]> =>
       requestJSON<Quest[]>("/quests", { headers: buildHeaders(token) }, "Failed to fetch quests"),
 
+    getByUser: async (
+      userId: number,
+      token: string,
+      completed?: boolean
+    ): Promise<Quest[]> => {
+      const params = new URLSearchParams();
+      if (completed !== undefined) {
+        params.set("completed", completed ? "true" : "false");
+      }
+
+      const query = params.toString();
+      return requestJSON<Quest[]>(
+        `/quests/user/${userId}${query ? `?${query}` : ""}`,
+        { headers: buildHeaders(token) },
+        "Failed to fetch user quests"
+      );
+    },
+
     getAllTemplates: async (token: string): Promise<QuestTemplate[]> =>
       requestJSON<QuestTemplate[]>(
         "/quests/templates/all",


### PR DESCRIPTION
## Summary
- load profile quest history from the existing user-scoped quest endpoint instead of the household-wide `/quests` list
- request only completed quests for the logged-in user
- keep the profile page logic focused on the current hero instead of filtering household history client-side

## Verification
- `bun run typecheck`
- `bun run build`
- local browser verification with Playwright against a seeded two-user home
- confirmed Alice's profile shows `Alice Only Quest`
- confirmed Alice's profile does not show `Bob Only Quest`