### PR TITLE
[codex] support shared quest participants

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -2,7 +2,7 @@
 
 FastAPI service for Majordomo.
 
-Last verified: 2026-02-12
+Last verified: 2026-04-16
 
 ## Run locally
 
@@ -46,3 +46,5 @@ uv run ruff format .
 
 - Treat OpenAPI + tests as contract source of truth.
 - If route behavior changes, update `docs/current-architecture.md` in the same PR.
+- Quests can have multiple participants via `quest_participant`; keep legacy `quest.user_id`
+  aligned to the primary participant for compatibility.

--- a/backend/README.md
+++ b/backend/README.md
@@ -47,4 +47,5 @@ uv run ruff format .
 - Treat OpenAPI + tests as contract source of truth.
 - If route behavior changes, update `docs/current-architecture.md` in the same PR.
 - Quests can have multiple participants via `quest_participant`; keep legacy `quest.user_id`
-  aligned to the primary participant for compatibility.
+  aligned to the first selected primary participant for compatibility. Treat it as a fallback
+  pointer, not the source of truth for assignment.

--- a/backend/app/crud/achievement.py
+++ b/backend/app/crud/achievement.py
@@ -3,7 +3,7 @@ from typing import Optional
 from sqlmodel import Session, func, or_, select
 
 from app.models.achievement import Achievement, AchievementCreate, UserAchievement
-from app.models.quest import Quest
+from app.models.quest import Quest, QuestParticipant
 from app.models.user import User
 
 
@@ -88,7 +88,12 @@ def delete_achievement(db: Session, achievement_id: int) -> bool:
 
 def get_user_quests_completed_count(db: Session, user_id: int) -> int:
     """Get total number of quests completed by a user"""
-    result = db.exec(select(func.count(Quest.id)).where(Quest.user_id == user_id).where(Quest.completed)).first()
+    result = db.exec(
+        select(func.count(Quest.id))
+        .join(QuestParticipant, QuestParticipant.quest_id == Quest.id)
+        .where(QuestParticipant.user_id == user_id)
+        .where(Quest.completed)
+    ).first()
     return result or 0
 
 
@@ -97,7 +102,8 @@ def get_user_bounties_completed_count(db: Session, user_id: int) -> int:
     # A bounty quest is identified by quest_type = "bounty" on the quest itself
     result = db.exec(
         select(func.count(Quest.id))
-        .where(Quest.user_id == user_id)
+        .join(QuestParticipant, QuestParticipant.quest_id == Quest.id)
+        .where(QuestParticipant.user_id == user_id)
         .where(Quest.completed)
         .where(Quest.quest_type == "bounty")
     ).first()

--- a/backend/app/crud/daily_bounty.py
+++ b/backend/app/crud/daily_bounty.py
@@ -8,7 +8,7 @@ from sqlmodel import Session, select
 
 from app.models.daily_bounty import DailyBounty
 from app.models.home import Home
-from app.models.quest import Quest
+from app.models.quest import Quest, QuestParticipant
 
 
 MIN_BOUNTY_AGE_HOURS = 48
@@ -50,8 +50,9 @@ def _get_eligible_active_quests(db: Session, home_id: int, user_id: int) -> list
     age_cutoff = datetime.now(timezone.utc) - timedelta(hours=MIN_BOUNTY_AGE_HOURS)
     candidates = db.exec(
         select(Quest)
+        .join(QuestParticipant, QuestParticipant.quest_id == Quest.id)
         .where(Quest.home_id == home_id)
-        .where(Quest.user_id == user_id)
+        .where(QuestParticipant.user_id == user_id)
         .where(Quest.completed == False)  # noqa: E712
         .where(Quest.created_at <= age_cutoff)
     ).all()

--- a/backend/app/crud/home.py
+++ b/backend/app/crud/home.py
@@ -8,7 +8,7 @@ from app.crud import reward as crud_reward
 from app.models.achievement import Achievement, UserAchievement
 from app.models.daily_bounty import DailyBounty
 from app.models.home import Home, HomeCreate
-from app.models.quest import Quest, QuestTemplate, UserTemplateSubscription
+from app.models.quest import Quest, QuestParticipant, QuestTemplate, UserTemplateSubscription
 from app.models.reward import Reward, UserRewardClaim
 from app.models.user import User
 
@@ -78,6 +78,7 @@ def delete_home(db: Session, home_id: int) -> bool:
     achievement_ids = db.exec(select(Achievement.id).where(Achievement.home_id == home_id)).all()
 
     db.exec(delete(DailyBounty).where(DailyBounty.home_id == home_id))
+    db.exec(delete(QuestParticipant).where(QuestParticipant.quest_id.in_(select(Quest.id).where(Quest.home_id == home_id))))
     db.exec(delete(Quest).where(Quest.home_id == home_id))
 
     if reward_ids:

--- a/backend/app/crud/quest.py
+++ b/backend/app/crud/quest.py
@@ -1,9 +1,10 @@
 from datetime import datetime, timezone
 from typing import Optional
 
+from sqlalchemy import delete
 from sqlmodel import Session, select
 
-from app.models.quest import Quest, QuestCreate, QuestCreateStandalone, QuestTemplate, QuestUpdate
+from app.models.quest import Quest, QuestCreate, QuestCreateStandalone, QuestParticipant, QuestTemplate, QuestUpdate
 
 
 def get_quest(db: Session, quest_id: int) -> Optional[Quest]:
@@ -22,8 +23,12 @@ def get_quests_by_home(db: Session, home_id: int) -> list[Quest]:
 
 
 def get_quests_by_user(db: Session, home_id: int, user_id: int, completed: Optional[bool] = None) -> list[Quest]:
-    """Get all quests for a user in a home, optionally filtered by completion status"""
-    query = select(Quest).where((Quest.home_id == home_id) & (Quest.user_id == user_id))
+    """Get all quests where a user is a participant, optionally filtered by completion status"""
+    query = (
+        select(Quest)
+        .join(QuestParticipant, QuestParticipant.quest_id == Quest.id)
+        .where((Quest.home_id == home_id) & (QuestParticipant.user_id == user_id))
+    )
 
     if completed is not None:
         query = query.where(Quest.completed == completed)
@@ -31,14 +36,87 @@ def get_quests_by_user(db: Session, home_id: int, user_id: int, completed: Optio
     return db.exec(query.order_by(Quest.created_at.desc())).all()
 
 
+def _dedupe_user_ids(user_ids: list[int]) -> list[int]:
+    """Preserve order while removing duplicate user IDs."""
+    seen: set[int] = set()
+    deduped: list[int] = []
+    for user_id in user_ids:
+        if user_id in seen:
+            continue
+        seen.add(user_id)
+        deduped.append(user_id)
+    return deduped
+
+
+def get_quest_participants(db: Session, quest_id: int) -> list[QuestParticipant]:
+    """Get all participants for a quest."""
+    return db.exec(
+        select(QuestParticipant)
+        .where(QuestParticipant.quest_id == quest_id)
+        .order_by(QuestParticipant.id)
+    ).all()
+
+
+def ensure_quest_participants(db: Session, quest: Quest) -> list[QuestParticipant]:
+    """
+    Ensure a quest has participant rows.
+
+    Existing production data is backfilled at startup, but this protects direct
+    model-created test data and any legacy rows created before the new table.
+    """
+    if quest.id is None:
+        return []
+
+    participants = get_quest_participants(db, quest.id)
+    if participants or quest.user_id is None:
+        return participants
+
+    participant = QuestParticipant(
+        quest_id=quest.id,
+        user_id=quest.user_id,
+        xp_awarded=quest.xp_reward if quest.completed else None,
+        gold_awarded=quest.gold_reward if quest.completed else None,
+        completed_at=quest.completed_at if quest.completed else None,
+    )
+    db.add(participant)
+    db.commit()
+    db.refresh(participant)
+    return [participant]
+
+
+def replace_quest_participants(db: Session, quest: Quest, participant_user_ids: list[int]) -> list[QuestParticipant]:
+    """Replace the users participating in a quest and keep legacy Quest.user_id aligned."""
+    if quest.id is None:
+        raise ValueError("Quest must be persisted before participants can be assigned")
+
+    deduped_user_ids = _dedupe_user_ids(participant_user_ids)
+    if not deduped_user_ids:
+        raise ValueError("Quest requires at least one participant")
+
+    db.exec(delete(QuestParticipant).where(QuestParticipant.quest_id == quest.id))
+
+    participants = [
+        QuestParticipant(quest_id=quest.id, user_id=participant_user_id)
+        for participant_user_id in deduped_user_ids
+    ]
+    for participant in participants:
+        db.add(participant)
+
+    quest.user_id = deduped_user_ids[0]
+    db.add(quest)
+    db.flush()
+    return participants
+
+
 def create_quest(
-    db: Session, home_id: int, created_by: int, user_id: int, quest_in: QuestCreate, template: QuestTemplate
+    db: Session, home_id: int, created_by: int, participant_user_ids: list[int], quest_in: QuestCreate, template: QuestTemplate
 ) -> Quest:
-    """Create a new quest instance for a user from a template, snapshotting template data"""
+    """Create a new quest instance for participants from a template, snapshotting template data"""
+    primary_user_id = participant_user_ids[0]
     db_quest = Quest(
         home_id=home_id,
         created_by=created_by,
-        user_id=user_id,
+        user_id=primary_user_id,
         quest_template_id=template.id,
         # Snapshot template data
         title=template.title,
@@ -52,19 +130,22 @@ def create_quest(
         due_in_hours=template.due_in_hours,
     )
     db.add(db_quest)
+    db.flush()
+    replace_quest_participants(db, db_quest, participant_user_ids)
     db.commit()
     db.refresh(db_quest)
     return db_quest
 
 
 def create_standalone_quest(
-    db: Session, home_id: int, created_by: int, user_id: int, quest_in: QuestCreateStandalone
+    db: Session, home_id: int, created_by: int, participant_user_ids: list[int], quest_in: QuestCreateStandalone
 ) -> Quest:
     """Create a standalone quest without a template"""
+    primary_user_id = participant_user_ids[0]
     db_quest = Quest(
         home_id=home_id,
         created_by=created_by,
-        user_id=user_id,
+        user_id=primary_user_id,
         quest_template_id=None,  # No template
         # Set fields directly from input
         title=quest_in.title,
@@ -76,6 +157,8 @@ def create_standalone_quest(
         due_in_hours=quest_in.due_in_hours,
     )
     db.add(db_quest)
+    db.flush()
+    replace_quest_participants(db, db_quest, participant_user_ids)
     db.commit()
     db.refresh(db_quest)
     return db_quest
@@ -110,10 +193,16 @@ def update_quest(db: Session, quest_id: int, quest_in: QuestUpdate) -> Optional[
         return None
 
     update_data = quest_in.model_dump(exclude_unset=True)
+    participant_user_ids = update_data.pop("participant_user_ids", None)
+    if participant_user_ids is None and update_data.get("user_id") is not None:
+        participant_user_ids = [update_data["user_id"]]
+
     for key, value in update_data.items():
         setattr(db_quest, key, value)
 
     db.add(db_quest)
+    if participant_user_ids is not None:
+        replace_quest_participants(db, db_quest, participant_user_ids)
     db.commit()
     db.refresh(db_quest)
     return db_quest
@@ -125,6 +214,7 @@ def delete_quest(db: Session, quest_id: int) -> bool:
     if not db_quest:
         return False
 
+    db.exec(delete(QuestParticipant).where(QuestParticipant.quest_id == quest_id))
     db.delete(db_quest)
     db.commit()
     return True

--- a/backend/app/crud/quest.py
+++ b/backend/app/crud/quest.py
@@ -37,7 +37,13 @@ def get_quests_by_user(db: Session, home_id: int, user_id: int, completed: Optio
 
 
 def _dedupe_user_ids(user_ids: list[int]) -> list[int]:
-    """Preserve order while removing duplicate user IDs."""
+    """
+    Preserve request order while removing duplicate user IDs.
+
+    API clients can send duplicate participant IDs. Collapsing them here avoids
+    unique-constraint failures and prevents duplicated reward shares while keeping
+    the first selected user as the legacy primary participant.
+    """
     seen: set[int] = set()
     deduped: list[int] = []
     for user_id in user_ids:
@@ -85,7 +91,12 @@ def ensure_quest_participants(db: Session, quest: Quest) -> list[QuestParticipan
 
 
 def replace_quest_participants(db: Session, quest: Quest, participant_user_ids: list[int]) -> list[QuestParticipant]:
-    """Replace the users participating in a quest and keep legacy Quest.user_id aligned."""
+    """
+    Replace the users participating in a quest and keep legacy Quest.user_id aligned.
+
+    Quest.user_id is no longer the sole assignee; it is the primary participant
+    retained for older API callers and UI paths that still expect a single user.
+    """
     if quest.id is None:
         raise ValueError("Quest must be persisted before participants can be assigned")
 

--- a/backend/app/crud/user.py
+++ b/backend/app/crud/user.py
@@ -3,7 +3,10 @@ from typing import Optional
 from sqlmodel import Session, delete, select
 
 from app.auth import hash_password
-from app.models.quest import QuestParticipant
+from app.models.achievement import UserAchievement
+from app.models.daily_bounty import DailyBounty
+from app.models.quest import Quest, QuestParticipant, UserTemplateSubscription
+from app.models.reward import UserRewardClaim
 from app.models.user import User, UserCreate, UserUpdate
 
 
@@ -119,6 +122,42 @@ def delete_user(db: Session, user_id: int) -> bool:
     if not db_user:
         return False
 
+    participant_quest_ids = db.exec(select(QuestParticipant.quest_id).where(QuestParticipant.user_id == user_id)).all()
+    primary_quest_ids = db.exec(select(Quest.id).where(Quest.user_id == user_id)).all()
+    affected_quest_ids = set(participant_quest_ids) | set(primary_quest_ids)
+
+    for quest_id in affected_quest_ids:
+        quest = db.get(Quest, quest_id)
+        if not quest:
+            continue
+
+        remaining_participants = db.exec(
+            select(QuestParticipant)
+            .where(QuestParticipant.quest_id == quest_id)
+            .where(QuestParticipant.user_id != user_id)
+            .order_by(QuestParticipant.id)
+        ).all()
+
+        if remaining_participants:
+            if quest.user_id == user_id:
+                quest.user_id = remaining_participants[0].user_id
+            if quest.created_by == user_id:
+                quest.created_by = quest.user_id
+            db.add(quest)
+            continue
+
+        db.exec(delete(DailyBounty).where(DailyBounty.quest_id == quest_id))
+        db.exec(delete(QuestParticipant).where(QuestParticipant.quest_id == quest_id))
+        db.delete(quest)
+
+    for quest in db.exec(select(Quest).where(Quest.created_by == user_id)).all():
+        quest.created_by = quest.user_id
+        db.add(quest)
+
+    db.exec(delete(DailyBounty).where(DailyBounty.user_id == user_id))
+    db.exec(delete(UserRewardClaim).where(UserRewardClaim.user_id == user_id))
+    db.exec(delete(UserAchievement).where(UserAchievement.user_id == user_id))
+    db.exec(delete(UserTemplateSubscription).where(UserTemplateSubscription.user_id == user_id))
     db.exec(delete(QuestParticipant).where(QuestParticipant.user_id == user_id))
     db.delete(db_user)
     db.commit()

--- a/backend/app/crud/user.py
+++ b/backend/app/crud/user.py
@@ -1,8 +1,9 @@
 from typing import Optional
 
-from sqlmodel import Session, select
+from sqlmodel import Session, delete, select
 
 from app.auth import hash_password
+from app.models.quest import QuestParticipant
 from app.models.user import User, UserCreate, UserUpdate
 
 
@@ -118,6 +119,7 @@ def delete_user(db: Session, user_id: int) -> bool:
     if not db_user:
         return False
 
+    db.exec(delete(QuestParticipant).where(QuestParticipant.user_id == user_id))
     db.delete(db_user)
     db.commit()
     return True

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -38,6 +38,9 @@ def ensure_runtime_schema_compatibility() -> None:
             connection.execute(text("UPDATE quest SET created_by = user_id WHERE created_by IS NULL"))
             connection.execute(text("CREATE INDEX IF NOT EXISTS ix_quest_created_by ON quest (created_by)"))
 
+        # Keep this idempotent backfill through the production rollout. It can be
+        # removed in a later cleanup once every deployed database has the table
+        # and historical quests have participant rows.
         connection.execute(
             text(
                 """

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -31,13 +31,42 @@ def ensure_runtime_schema_compatibility() -> None:
         return
 
     column_names = {column["name"] for column in inspector.get_columns("quest")}
-    if "created_by" in column_names:
-        return
 
     with engine.begin() as connection:
-        connection.execute(text("ALTER TABLE quest ADD COLUMN created_by INTEGER"))
-        connection.execute(text("UPDATE quest SET created_by = user_id WHERE created_by IS NULL"))
-        connection.execute(text("CREATE INDEX IF NOT EXISTS ix_quest_created_by ON quest (created_by)"))
+        if "created_by" not in column_names:
+            connection.execute(text("ALTER TABLE quest ADD COLUMN created_by INTEGER"))
+            connection.execute(text("UPDATE quest SET created_by = user_id WHERE created_by IS NULL"))
+            connection.execute(text("CREATE INDEX IF NOT EXISTS ix_quest_created_by ON quest (created_by)"))
+
+        connection.execute(
+            text(
+                """
+                INSERT INTO quest_participant (
+                    quest_id,
+                    user_id,
+                    xp_awarded,
+                    gold_awarded,
+                    completed_at,
+                    created_at
+                )
+                SELECT
+                    q.id,
+                    q.user_id,
+                    CASE WHEN q.completed THEN q.xp_reward ELSE NULL END,
+                    CASE WHEN q.completed THEN q.gold_reward ELSE NULL END,
+                    CASE WHEN q.completed THEN q.completed_at ELSE NULL END,
+                    COALESCE(q.completed_at, q.created_at, CURRENT_TIMESTAMP)
+                FROM quest q
+                WHERE q.user_id IS NOT NULL
+                  AND NOT EXISTS (
+                    SELECT 1
+                    FROM quest_participant qp
+                    WHERE qp.quest_id = q.id
+                      AND qp.user_id = q.user_id
+                  )
+                """
+            )
+        )
 
 
 def get_session():

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,7 +1,7 @@
 from app.models.achievement import Achievement, UserAchievement
 from app.models.daily_bounty import DailyBounty
 from app.models.home import Home
-from app.models.quest import Quest, QuestTemplate
+from app.models.quest import Quest, QuestParticipant, QuestTemplate
 from app.models.reward import Reward, UserRewardClaim
 from app.models.user import User
 
@@ -9,6 +9,7 @@ __all__ = [
     "Home",
     "User",
     "Quest",
+    "QuestParticipant",
     "QuestTemplate",
     "Reward",
     "UserRewardClaim",

--- a/backend/app/models/quest.py
+++ b/backend/app/models/quest.py
@@ -121,7 +121,7 @@ class QuestTemplateUpdate(SQLModel):
 
 
 class Quest(SQLModel, table=True):
-    """Quest model representing a task instance for a user"""
+    """Quest model representing a task instance for one or more users"""
 
     id: Optional[int] = Field(default=None, primary_key=True)
     home_id: int = Field(foreign_key="home.id", index=True)
@@ -138,7 +138,7 @@ class Quest(SQLModel, table=True):
     description: Optional[str] = Field(default=None, max_length=1000)
     tags: Optional[str] = Field(default=None, max_length=500)
 
-    # Rewards: base value at creation, updated to actual earned at completion
+    # Rewards: base total value for the quest. Actual earned shares live on QuestParticipant.
     xp_reward: int = Field(default=0, ge=0)
     gold_reward: int = Field(default=0, ge=0)
 
@@ -159,6 +159,39 @@ class Quest(SQLModel, table=True):
         sa_relationship_kwargs={"foreign_keys": "Quest.user_id"},
     )
     template: Optional[QuestTemplate] = Relationship(back_populates="quests")
+    participants: list["QuestParticipant"] = Relationship(back_populates="quest")
+
+
+class QuestParticipant(SQLModel, table=True):
+    """Links a quest instance to each user participating in it."""
+
+    __tablename__ = "quest_participant"
+    __table_args__ = (
+        UniqueConstraint("quest_id", "user_id", name="unique_quest_participant"),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    quest_id: int = Field(foreign_key="quest.id", index=True)
+    user_id: int = Field(foreign_key="user.id", index=True)
+    xp_awarded: Optional[int] = Field(default=None, ge=0)
+    gold_awarded: Optional[int] = Field(default=None, ge=0)
+    completed_at: Optional[datetime] = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+    quest: Quest = Relationship(back_populates="participants")
+    user: "User" = Relationship(back_populates="quest_participations")
+
+
+class QuestParticipantRead(SQLModel):
+    """Schema for reading quest participant data."""
+
+    id: int
+    quest_id: int
+    user_id: int
+    xp_awarded: Optional[int]
+    gold_awarded: Optional[int]
+    completed_at: Optional[datetime]
+    created_at: datetime
 
 
 class QuestRead(SQLModel):
@@ -189,6 +222,7 @@ class QuestRead(SQLModel):
     corrupted_at: Optional[datetime]
     # Include template data for convenience (may be null for standalone quests)
     template: Optional[QuestTemplateRead]
+    participants: list[QuestParticipantRead] = Field(default_factory=list)
 
 
 class QuestCreate(SQLModel):
@@ -196,6 +230,7 @@ class QuestCreate(SQLModel):
 
     quest_template_id: int
     due_date: Optional[datetime] = None  # optional user-set deadline
+    participant_user_ids: Optional[list[int]] = None
 
 
 class QuestCreateStandalone(SQLModel):
@@ -208,6 +243,7 @@ class QuestCreateStandalone(SQLModel):
     xp_reward: int = Field(default=10, ge=0, le=10000)
     gold_reward: int = Field(default=5, ge=0, le=10000)
     due_in_hours: Optional[int] = Field(default=None, ge=1, le=8760)
+    participant_user_ids: Optional[list[int]] = None
 
 
 class QuestUpdate(SQLModel):
@@ -219,6 +255,7 @@ class QuestUpdate(SQLModel):
     xp_reward: Optional[int] = None
     gold_reward: Optional[int] = None
     user_id: Optional[int] = None
+    participant_user_ids: Optional[list[int]] = None
     completed: Optional[bool] = None
     quest_type: Optional[str] = None
     due_in_hours: Optional[int] = Field(default=None, ge=1, le=8760)

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -6,7 +6,7 @@ from sqlmodel import Field, Relationship, SQLModel
 if TYPE_CHECKING:
     from app.models.achievement import UserAchievement
     from app.models.home import Home
-    from app.models.quest import Quest, UserTemplateSubscription
+    from app.models.quest import Quest, QuestParticipant, UserTemplateSubscription
     from app.models.reward import UserRewardClaim
 
 
@@ -33,6 +33,7 @@ class User(SQLModel, table=True):
         back_populates="user",
         sa_relationship_kwargs={"foreign_keys": "Quest.user_id"},
     )
+    quest_participations: list["QuestParticipant"] = Relationship(back_populates="user")
     reward_claims: list["UserRewardClaim"] = Relationship(back_populates="user")
     user_achievements: list["UserAchievement"] = Relationship(back_populates="user")
     template_subscriptions: list["UserTemplateSubscription"] = Relationship(back_populates="user")

--- a/backend/app/routes/quest.py
+++ b/backend/app/routes/quest.py
@@ -61,6 +61,12 @@ def _calculate_corruption_debuff(db: Session, home_id: int, user: User) -> float
 
 
 def _dedupe_user_ids(user_ids: list[int]) -> list[int]:
+    """
+    Preserve the caller's first-choice order while removing duplicates.
+
+    The public API accepts raw arrays, so this guards direct clients from
+    creating duplicate participant rows or duplicate reward shares.
+    """
     seen: set[int] = set()
     deduped: list[int] = []
     for user_id in user_ids:
@@ -79,6 +85,9 @@ def _resolve_participant_user_ids(
 ) -> list[int]:
     """
     Resolve participant IDs from the new request body field or legacy user_id query param.
+
+    `participant_user_ids` is preferred. `user_id` remains accepted so older
+    clients can still create single-participant quests during the transition.
     """
     resolved_user_ids = (
         participant_user_ids

--- a/backend/app/routes/quest.py
+++ b/backend/app/routes/quest.py
@@ -60,6 +60,51 @@ def _calculate_corruption_debuff(db: Session, home_id: int, user: User) -> float
     return multiplier
 
 
+def _dedupe_user_ids(user_ids: list[int]) -> list[int]:
+    seen: set[int] = set()
+    deduped: list[int] = []
+    for user_id in user_ids:
+        if user_id in seen:
+            continue
+        seen.add(user_id)
+        deduped.append(user_id)
+    return deduped
+
+
+def _resolve_participant_user_ids(
+    db: Session,
+    home_id: int,
+    legacy_user_id: Optional[int],
+    participant_user_ids: Optional[list[int]],
+) -> list[int]:
+    """
+    Resolve participant IDs from the new request body field or legacy user_id query param.
+    """
+    resolved_user_ids = (
+        participant_user_ids
+        if participant_user_ids is not None
+        else ([legacy_user_id] if legacy_user_id is not None else [])
+    )
+    resolved_user_ids = _dedupe_user_ids([user_id for user_id in resolved_user_ids if user_id is not None])
+
+    if not resolved_user_ids:
+        raise HTTPException(status_code=400, detail="Quest requires at least one participant")
+
+    for participant_user_id in resolved_user_ids:
+        user = crud_user.get_user(db, participant_user_id)
+        if not user or user.home_id != home_id:
+            raise HTTPException(status_code=404, detail="User not found in home")
+
+    return resolved_user_ids
+
+
+def _split_reward(total: int, participant_count: int) -> list[int]:
+    """Split an integer reward across participants while preserving the total."""
+    base_share = total // participant_count
+    remainder = total % participant_count
+    return [base_share + (1 if index < remainder else 0) for index in range(participant_count)]
+
+
 # GET endpoints
 @router.get("/templates/all", response_model=list[QuestTemplateRead])
 def get_all_quest_templates(db: Session = Depends(get_db), auth: dict = Depends(get_current_user)):
@@ -135,42 +180,40 @@ def get_quest_template(template_id: int, db: Session = Depends(get_db), auth: di
 # POST endpoints
 @router.post("", response_model=QuestRead)
 def create_quest(
-    quest: QuestCreate, user_id: int = Query(...), db: Session = Depends(get_db), auth: dict = Depends(get_current_user)
+    quest: QuestCreate,
+    user_id: Optional[int] = Query(None),
+    db: Session = Depends(get_db),
+    auth: dict = Depends(get_current_user),
 ):
-    """Create a new quest instance for a user"""
+    """Create a new quest instance for one or more participants"""
     home_id = auth["home_id"]
-
-    # Verify user exists in home and belongs to authenticated home
-    user = crud_user.get_user(db, user_id)
-    if not user or user.home_id != home_id:
-        raise HTTPException(status_code=404, detail="User not found in home")
+    participant_user_ids = _resolve_participant_user_ids(db, home_id, user_id, quest.participant_user_ids)
 
     # Verify template exists in home
     template = crud_quest_template.get_quest_template(db, quest.quest_template_id)
     if not template or template.home_id != home_id:
         raise HTTPException(status_code=404, detail="Quest template not found in home")
 
-    return crud_quest.create_quest(db, home_id, auth["user_id"], user_id, quest, template)
+    return crud_quest.create_quest(db, home_id, auth["user_id"], participant_user_ids, quest, template)
 
 
 @router.post("/standalone", response_model=QuestRead)
 def create_standalone_quest(
-    quest: QuestCreateStandalone, user_id: int = Query(...), db: Session = Depends(get_db), auth: dict = Depends(get_current_user)
+    quest: QuestCreateStandalone,
+    user_id: Optional[int] = Query(None),
+    db: Session = Depends(get_db),
+    auth: dict = Depends(get_current_user),
 ):
     """Create a standalone quest without a template"""
     home_id = auth["home_id"]
+    participant_user_ids = _resolve_participant_user_ids(db, home_id, user_id, quest.participant_user_ids)
 
-    # Verify user exists in home and belongs to authenticated home
-    user = crud_user.get_user(db, user_id)
-    if not user or user.home_id != home_id:
-        raise HTTPException(status_code=404, detail="User not found in home")
-
-    return crud_quest.create_standalone_quest(db, home_id, auth["user_id"], user_id, quest)
+    return crud_quest.create_standalone_quest(db, home_id, auth["user_id"], participant_user_ids, quest)
 
 
 @router.post("/ai-scribe", response_model=QuestRead)
 def create_ai_scribe_quest(
-    user_id: int = Query(...),
+    user_id: Optional[int] = Query(None),
     skip_ai: bool = Query(False),
     quest_data: QuestCreateStandalone = None,
     db: Session = Depends(get_db),
@@ -180,7 +223,7 @@ def create_ai_scribe_quest(
     """
     Create a standalone quest with optional AI-generated content.
 
-    - **user_id**: User ID to assign quest to
+    - **user_id**: Legacy single user ID to assign quest to
     - **skip_ai**: Set to true to skip AI generation (default: false)
     - **quest_data**: Quest data (title required, other fields optional)
 
@@ -188,14 +231,13 @@ def create_ai_scribe_quest(
     display_name, description, and tags in the background.
     """
     home_id = auth["home_id"]
+    if quest_data is None:
+        raise HTTPException(status_code=400, detail="Quest data is required")
 
-    # Verify user exists in home
-    user = crud_user.get_user(db, user_id)
-    if not user or user.home_id != home_id:
-        raise HTTPException(status_code=404, detail="User not found in home")
+    participant_user_ids = _resolve_participant_user_ids(db, home_id, user_id, quest_data.participant_user_ids)
 
     # Create standalone quest
-    quest = crud_quest.create_standalone_quest(db, home_id, auth["user_id"], user_id, quest_data)
+    quest = crud_quest.create_standalone_quest(db, home_id, auth["user_id"], participant_user_ids, quest_data)
 
     # Trigger AI generation in background (unless skipping)
     if not skip_ai:
@@ -210,7 +252,8 @@ def create_ai_scribe_quest(
 
 @router.post("/random", response_model=QuestRead)
 def create_random_quest(
-    user_id: int = Query(...),
+    user_id: Optional[int] = Query(None),
+    participant_user_ids: Optional[list[int]] = Query(None),
     db: Session = Depends(get_db),
     auth: dict = Depends(get_current_user),
 ):
@@ -222,11 +265,7 @@ def create_random_quest(
     import random
 
     home_id = auth["home_id"]
-
-    # Verify user exists in home
-    user = crud_user.get_user(db, user_id)
-    if not user or user.home_id != home_id:
-        raise HTTPException(status_code=404, detail="User not found in home")
+    resolved_participant_user_ids = _resolve_participant_user_ids(db, home_id, user_id, participant_user_ids)
 
     # Sample quest data
     samples = [
@@ -272,7 +311,9 @@ def create_random_quest(
         gold_reward=gold_reward,
     )
 
-    quest = crud_quest.create_standalone_quest(db, home_id, auth["user_id"], user_id, quest_data)
+    quest = crud_quest.create_standalone_quest(
+        db, home_id, auth["user_id"], resolved_participant_user_ids, quest_data
+    )
     return quest
 
 
@@ -325,6 +366,8 @@ def generate_quest_instance(
         schedule=template.schedule,
     )
     db.add(new_quest)
+    db.flush()
+    crud_quest.replace_quest_participants(db, new_quest, [auth["user_id"]])
 
     # Update last_generated_at
     template.last_generated_at = now
@@ -379,102 +422,143 @@ def complete_quest(quest_id: int, db: Session = Depends(get_db), auth: dict = De
             ),
         )
 
-    # Get user for consumable checks and debuff calculation
-    user = crud_user.get_user(db, quest.user_id)
-    if not user:
-        raise HTTPException(
-            status_code=404,
-            detail=create_error_detail(ErrorCode.USER_NOT_FOUND, details={"user_id": quest.user_id}),
-        )
+    participants = crud_quest.ensure_quest_participants(db, quest)
+    if not participants:
+        raise HTTPException(status_code=400, detail="Quest has no participants")
 
-    # Resolve today's bounty decision for the quest owner.
-    today_bounty = crud_daily_bounty.get_or_create_today_bounty(db, auth["home_id"], quest.user_id)
-    is_daily_bounty = bool(
-        today_bounty.status == "assigned" and today_bounty.quest_id == quest.id
-    )
+    participants = sorted(participants, key=lambda participant: participant.user_id)
+    participant_users: dict[int, User] = {}
+    for participant in participants:
+        participant_user = crud_user.get_user(db, participant.user_id)
+        if not participant_user or participant_user.home_id != auth["home_id"]:
+            raise HTTPException(
+                status_code=404,
+                detail=create_error_detail(ErrorCode.USER_NOT_FOUND, details={"user_id": participant.user_id}),
+            )
+        participant_users[participant.user_id] = participant_user
 
     # Check if quest is corrupted (overdue) - for display purposes only (not bonus rewards)
     is_corrupted = quest.quest_type == "corrupted"
 
-    # Calculate corruption debuff (house-wide penalty)
-    corruption_debuff_multiplier = _calculate_corruption_debuff(db, auth["home_id"], user)
-
-    # Check for active XP boost (Heroic Elixir)
-    has_xp_boost = user.active_xp_boost_count > 0
-
-    # Award XP and gold to user from template
-    # Apply order: base → corruption_debuff → bounty_bonus → xp_boost
-    xp_awarded = 0
-    gold_awarded = 0
-    base_xp = 0
-    base_gold = 0
-    bounty_gold_multiplier = 3 if is_daily_bounty else 1
-    bounty_xp_multiplier = 1
-    xp_boost_multiplier = 2 if has_xp_boost else 1
-
-    # Use quest's snapshot fields as base values
+    participant_count = len(participants)
     base_xp = quest.xp_reward
     base_gold = quest.gold_reward
+    base_xp_shares = _split_reward(base_xp, participant_count)
+    base_gold_shares = _split_reward(base_gold, participant_count)
+    completed_at = datetime.now(timezone.utc)
+    bounty_decisions = {
+        participant.user_id: crud_daily_bounty.get_or_create_today_bounty(db, auth["home_id"], participant.user_id)
+        for participant in participants
+    }
 
-    # Apply corruption debuff to both XP and gold
-    xp_after_debuff = base_xp * corruption_debuff_multiplier
-    gold_after_debuff = base_gold * corruption_debuff_multiplier
+    participant_reward_breakdowns = []
+    total_xp_awarded = 0
+    total_gold_awarded = 0
+    any_daily_bounty = False
+    any_xp_boost = False
+    first_participant_xp_boost_remaining = 0
 
-    # Apply bounty bonus: daily bounty triples gold only (XP unchanged)
-    xp_after_bounty = xp_after_debuff * bounty_xp_multiplier
-    gold_after_bounty = gold_after_debuff * bounty_gold_multiplier
+    for index, participant in enumerate(participants):
+        user = participant_users[participant.user_id]
 
-    # Apply XP boost only to XP (not gold)
-    xp_awarded = int(xp_after_bounty * xp_boost_multiplier)
-    gold_awarded = int(gold_after_bounty)
+        today_bounty = bounty_decisions[user.id]
+        is_daily_bounty = bool(today_bounty.status == "assigned" and today_bounty.quest_id == quest.id)
+        any_daily_bounty = any_daily_bounty or is_daily_bounty
 
-    # Mark quest as completed and store actual earned rewards
-    quest = crud_quest.complete_quest(db, quest_id, final_xp=xp_awarded, final_gold=gold_awarded)
+        corruption_debuff_multiplier = _calculate_corruption_debuff(db, auth["home_id"], user)
+        has_xp_boost = user.active_xp_boost_count > 0
+        any_xp_boost = any_xp_boost or has_xp_boost
 
-    try:
-        crud_user.add_xp(db, quest.user_id, xp_awarded)
-        crud_user.add_gold(db, quest.user_id, gold_awarded)
-    except ValueError as e:
-        error_msg = str(e)
-        # Determine error code based on error message
-        if "XP amount" in error_msg:
-            error_code = ErrorCode.NEGATIVE_XP
-        elif "Insufficient gold" in error_msg:
-            error_code = ErrorCode.INSUFFICIENT_GOLD
-        else:
-            error_code = ErrorCode.INVALID_INPUT
+        participant_base_xp = base_xp_shares[index]
+        participant_base_gold = base_gold_shares[index]
+        bounty_gold_multiplier = 3 if is_daily_bounty else 1
+        bounty_xp_multiplier = 1
+        xp_boost_multiplier = 2 if has_xp_boost else 1
 
-        raise HTTPException(
-            status_code=400,
-            detail=create_error_detail(error_code, message=error_msg, details={"quest_id": quest_id}),
+        xp_after_debuff = participant_base_xp * corruption_debuff_multiplier
+        gold_after_debuff = participant_base_gold * corruption_debuff_multiplier
+        xp_after_bounty = xp_after_debuff * bounty_xp_multiplier
+        gold_after_bounty = gold_after_debuff * bounty_gold_multiplier
+        xp_awarded = int(xp_after_bounty * xp_boost_multiplier)
+        gold_awarded = int(gold_after_bounty)
+
+        participant.xp_awarded = xp_awarded
+        participant.gold_awarded = gold_awarded
+        participant.completed_at = completed_at
+        db.add(participant)
+
+        user.xp += xp_awarded
+        user.level = crud_user.calculate_level(user.xp)
+        user.gold_balance += gold_awarded
+
+        if has_xp_boost:
+            user.active_xp_boost_count -= 1
+
+        db.add(user)
+
+        if index == 0:
+            first_participant_xp_boost_remaining = user.active_xp_boost_count
+
+        total_xp_awarded += xp_awarded
+        total_gold_awarded += gold_awarded
+        participant_reward_breakdowns.append(
+            {
+                "user_id": user.id,
+                "xp": xp_awarded,
+                "gold": gold_awarded,
+                "base_xp": participant_base_xp,
+                "base_gold": participant_base_gold,
+                "is_daily_bounty": is_daily_bounty,
+                "is_corrupted": is_corrupted,
+                "corruption_debuff": corruption_debuff_multiplier,
+                "bounty_multiplier": bounty_gold_multiplier,
+                "bounty_gold_multiplier": bounty_gold_multiplier,
+                "bounty_xp_multiplier": bounty_xp_multiplier,
+                "xp_boost_active": has_xp_boost,
+                "xp_boost_remaining": user.active_xp_boost_count,
+            }
         )
 
-    # Decrement XP boost counter if active
-    if has_xp_boost:
-        user.active_xp_boost_count -= 1
-        db.add(user)
-        db.commit()
+    quest.completed = True
+    quest.completed_at = completed_at
+    db.add(quest)
+
+    db.commit()
+    db.refresh(quest)
 
     # Check and award any newly earned achievements
-    newly_awarded_achievements = crud_achievement.check_and_award_achievements(db, quest.user_id)
+    newly_awarded_achievements = []
+    for participant in participants:
+        for user_achievement in crud_achievement.check_and_award_achievements(db, participant.user_id):
+            newly_awarded_achievements.append(
+                {
+                    "user_id": participant.user_id,
+                    "id": user_achievement.achievement_id,
+                    "unlocked_at": user_achievement.unlocked_at,
+                }
+            )
 
     return {
         "quest": QuestRead.model_validate(quest),
         "rewards": {
-            "xp": xp_awarded,
-            "gold": gold_awarded,
+            "xp": total_xp_awarded,
+            "gold": total_gold_awarded,
             "base_xp": base_xp,
             "base_gold": base_gold,
-            "is_daily_bounty": is_daily_bounty,
+            "is_daily_bounty": any_daily_bounty,
             "is_corrupted": is_corrupted,
-            "corruption_debuff": corruption_debuff_multiplier,
-            "bounty_multiplier": bounty_gold_multiplier,
-            "bounty_gold_multiplier": bounty_gold_multiplier,
-            "bounty_xp_multiplier": bounty_xp_multiplier,
-            "xp_boost_active": has_xp_boost,
-            "xp_boost_remaining": user.active_xp_boost_count,  # After decrement
+            "corruption_debuff": min(
+                (reward["corruption_debuff"] for reward in participant_reward_breakdowns),
+                default=1.0,
+            ),
+            "bounty_multiplier": 3 if any_daily_bounty else 1,
+            "bounty_gold_multiplier": 3 if any_daily_bounty else 1,
+            "bounty_xp_multiplier": 1,
+            "xp_boost_active": any_xp_boost,
+            "xp_boost_remaining": first_participant_xp_boost_remaining,
+            "participants": participant_reward_breakdowns,
         },
-        "achievements": [{"id": ua.achievement_id, "unlocked_at": ua.unlocked_at} for ua in newly_awarded_achievements],
+        "achievements": newly_awarded_achievements,
     }
 
 
@@ -807,13 +891,27 @@ def update_quest(
     if not quest or quest.home_id != auth["home_id"]:
         raise HTTPException(status_code=404, detail="Quest not found")
 
-    if quest.completed and quest_update and quest_update.user_id is not None:
+    is_reassigning = bool(
+        quest_update
+        and (quest_update.user_id is not None or quest_update.participant_user_ids is not None)
+    )
+    if quest.completed and is_reassigning:
         raise HTTPException(status_code=400, detail="Completed quests cannot be reassigned")
 
-    if quest_update and quest_update.user_id is not None:
+    if quest_update and quest_update.participant_user_ids is not None:
+        participant_user_ids = _resolve_participant_user_ids(
+            db,
+            auth["home_id"],
+            None,
+            quest_update.participant_user_ids,
+        )
+        quest_update.participant_user_ids = participant_user_ids
+        quest_update.user_id = participant_user_ids[0]
+    elif quest_update and quest_update.user_id is not None:
         target_user = crud_user.get_user(db, quest_update.user_id)
         if not target_user or target_user.home_id != auth["home_id"]:
             raise HTTPException(status_code=400, detail="Quest owner must belong to your home")
+        quest_update.participant_user_ids = [quest_update.user_id]
 
     quest = crud_quest.update_quest(db, quest_id, quest_update)
     return quest

--- a/backend/app/routes/triggers.py
+++ b/backend/app/routes/triggers.py
@@ -39,7 +39,7 @@ def trigger_quest(
         db,
         auth["home_id"],
         auth["user_id"],
-        auth["user_id"],
+        [auth["user_id"]],
         quest_in,
         template,
     )
@@ -48,6 +48,14 @@ def trigger_quest(
     base_xp = quest.xp_reward
     base_gold = quest.gold_reward
     quest = crud_quest.complete_quest(db, quest.id, final_xp=base_xp, final_gold=base_gold)
+    participants = crud_quest.ensure_quest_participants(db, quest)
+    for participant in participants:
+        if participant.user_id == auth["user_id"]:
+            participant.xp_awarded = base_xp
+            participant.gold_awarded = base_gold
+            participant.completed_at = quest.completed_at
+            db.add(participant)
+    db.commit()
 
     # Award XP and gold
     user = crud_user.add_xp(db, auth["user_id"], base_xp)

--- a/backend/app/services/recurring_quests.py
+++ b/backend/app/services/recurring_quests.py
@@ -8,7 +8,7 @@ from typing import Optional
 from sqlmodel import Session, or_, select
 
 from app.crud import quest as crud_quest
-from app.models.quest import Quest, QuestTemplate, UserTemplateSubscription
+from app.models.quest import Quest, QuestParticipant, QuestTemplate, UserTemplateSubscription
 from app.models.user import User
 
 
@@ -232,8 +232,9 @@ def generate_due_quests(home_id: int, session: Session) -> None:
                 # Check if incomplete instance already exists for THIS USER (skip if so)
                 existing = session.exec(
                     select(Quest)
+                    .join(QuestParticipant, QuestParticipant.quest_id == Quest.id)
                     .where(Quest.quest_template_id == subscription.quest_template_id)
-                    .where(Quest.user_id == subscription.user_id)
+                    .where(QuestParticipant.user_id == subscription.user_id)
                     .where(Quest.completed == False)  # noqa: E712
                 ).first()
 

--- a/backend/app/services/recurring_quests.py
+++ b/backend/app/services/recurring_quests.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 from sqlmodel import Session, or_, select
 
+from app.crud import quest as crud_quest
 from app.models.quest import Quest, QuestTemplate, UserTemplateSubscription
 from app.models.user import User
 
@@ -269,6 +270,9 @@ def generate_due_quests(home_id: int, session: Session) -> None:
                     due_date=due_date,
                 )
                 session.add(new_quest)
+                session.flush()
+
+                crud_quest.replace_quest_participants(session, new_quest, [subscription.user_id])
 
                 # Update subscription's last_generated_at to prevent duplicate generation
                 subscription.last_generated_at = now

--- a/backend/tests/test_quest_participants.py
+++ b/backend/tests/test_quest_participants.py
@@ -50,6 +50,24 @@ def test_user_quest_list_includes_shared_participation(client: TestClient, db_ho
     assert [quest["id"] for quest in response.json()] == [quest_id]
 
 
+def test_create_shared_quest_dedupes_participant_ids(client: TestClient, db_home_with_users, auth_context):
+    home, user1, user2 = db_home_with_users
+    auth_context.set_user(user1.id, home.id)
+
+    response = client.post(
+        "/api/quests/standalone",
+        json={
+            "title": "Duplicate participant quest",
+            "participant_user_ids": [user1.id, user2.id, user1.id],
+        },
+    )
+
+    assert response.status_code == 200
+    quest = response.json()
+    assert quest["user_id"] == user1.id
+    assert _participant_user_ids(quest) == [user1.id, user2.id]
+
+
 def test_complete_shared_quest_splits_rewards(client: TestClient, db_home_with_users, auth_context):
     home, user1, user2 = db_home_with_users
     auth_context.set_user(user1.id, home.id)

--- a/backend/tests/test_quest_participants.py
+++ b/backend/tests/test_quest_participants.py
@@ -1,0 +1,147 @@
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.models.home import Home
+from app.models.user import User
+
+
+def _participant_user_ids(quest: dict) -> list[int]:
+    return sorted(participant["user_id"] for participant in quest["participants"])
+
+
+def test_create_shared_standalone_quest(client: TestClient, db_home_with_users, auth_context):
+    home, user1, user2 = db_home_with_users
+    auth_context.set_user(user1.id, home.id)
+
+    response = client.post(
+        "/api/quests/standalone",
+        json={
+            "title": "Clean together",
+            "xp_reward": 21,
+            "gold_reward": 11,
+            "participant_user_ids": [user1.id, user2.id],
+        },
+    )
+
+    assert response.status_code == 200
+    quest = response.json()
+    assert quest["user_id"] == user1.id
+    assert _participant_user_ids(quest) == [user1.id, user2.id]
+
+
+def test_user_quest_list_includes_shared_participation(client: TestClient, db_home_with_users, auth_context):
+    home, user1, user2 = db_home_with_users
+    auth_context.set_user(user1.id, home.id)
+
+    create_response = client.post(
+        "/api/quests/standalone",
+        json={
+            "title": "Shared list quest",
+            "xp_reward": 10,
+            "gold_reward": 5,
+            "participant_user_ids": [user1.id, user2.id],
+        },
+    )
+    quest_id = create_response.json()["id"]
+
+    response = client.get(f"/api/quests/user/{user2.id}")
+
+    assert response.status_code == 200
+    assert [quest["id"] for quest in response.json()] == [quest_id]
+
+
+def test_complete_shared_quest_splits_rewards(client: TestClient, db_home_with_users, auth_context):
+    home, user1, user2 = db_home_with_users
+    auth_context.set_user(user1.id, home.id)
+
+    create_response = client.post(
+        "/api/quests/standalone",
+        json={
+            "title": "Shared reward quest",
+            "xp_reward": 21,
+            "gold_reward": 11,
+            "participant_user_ids": [user1.id, user2.id],
+        },
+    )
+    quest_id = create_response.json()["id"]
+
+    complete_response = client.post(f"/api/quests/{quest_id}/complete")
+
+    assert complete_response.status_code == 200
+    result = complete_response.json()
+    assert result["quest"]["completed"] is True
+    assert result["rewards"]["xp"] == 21
+    assert result["rewards"]["gold"] == 11
+
+    participant_rewards = {
+        reward["user_id"]: reward for reward in result["rewards"]["participants"]
+    }
+    assert participant_rewards[user1.id]["xp"] == 11
+    assert participant_rewards[user1.id]["gold"] == 6
+    assert participant_rewards[user2.id]["xp"] == 10
+    assert participant_rewards[user2.id]["gold"] == 5
+
+    user1_stats = client.get(f"/api/users/{user1.id}").json()
+    user2_stats = client.get(f"/api/users/{user2.id}").json()
+    assert user1_stats["xp"] == 11
+    assert user1_stats["gold_balance"] == 6
+    assert user2_stats["xp"] == 10
+    assert user2_stats["gold_balance"] == 5
+
+
+def test_shared_quest_rejects_participant_outside_home(
+    client: TestClient,
+    db: Session,
+    db_home_with_users,
+    auth_context,
+):
+    home, user1, _user2 = db_home_with_users
+    auth_context.set_user(user1.id, home.id)
+
+    other_home = Home(name="Other Home", invite_code="OTHER123")
+    db.add(other_home)
+    db.commit()
+    db.refresh(other_home)
+    outsider = User(
+        username="outsider",
+        email="outsider@test.com",
+        password_hash="$2b$12$test_hash_3",
+        home_id=other_home.id,
+    )
+    db.add(outsider)
+    db.commit()
+    db.refresh(outsider)
+
+    response = client.post(
+        "/api/quests/standalone",
+        json={
+            "title": "Invalid shared quest",
+            "participant_user_ids": [user1.id, outsider.id],
+        },
+    )
+
+    assert response.status_code == 404
+
+
+def test_completed_shared_quest_party_cannot_change(client: TestClient, db_home_with_users, auth_context):
+    home, user1, user2 = db_home_with_users
+    auth_context.set_user(user1.id, home.id)
+
+    create_response = client.post(
+        "/api/quests/standalone",
+        json={
+            "title": "Locked party quest",
+            "participant_user_ids": [user1.id, user2.id],
+        },
+    )
+    quest_id = create_response.json()["id"]
+    complete_response = client.post(f"/api/quests/{quest_id}/complete")
+    assert complete_response.status_code == 200
+
+    response = client.put(
+        f"/api/quests/{quest_id}",
+        json={"participant_user_ids": [user1.id]},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Completed quests cannot be reassigned"

--- a/backend/tests/test_recurring_quests.py
+++ b/backend/tests/test_recurring_quests.py
@@ -8,7 +8,7 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session, select
 
-from app.models.quest import Quest, QuestTemplate, UserTemplateSubscription
+from app.models.quest import Quest, QuestParticipant, QuestTemplate, UserTemplateSubscription
 from app.services.recurring_quests import (
     calculate_next_generation_time,
     generate_due_quests,
@@ -390,6 +390,8 @@ def test_generate_skips_when_incomplete_exists(db: Session, db_home_with_users):
         completed=False,
     )
     db.add(existing_quest)
+    db.flush()
+    db.add(QuestParticipant(quest_id=existing_quest.id, user_id=user.id))
     db.commit()
 
     # Mock time as 9:00 AM (after scheduled time)
@@ -403,6 +405,59 @@ def test_generate_skips_when_incomplete_exists(db: Session, db_home_with_users):
     # Should NOT create new quest (already have incomplete one)
     quests = db.exec(select(Quest).where(Quest.quest_template_id == template.id)).all()
     assert len(quests) == 1  # Only the existing one
+
+
+def test_generate_skips_existing_shared_instance_for_participant(db: Session, db_home_with_users):
+    """Test generation skips shared quests where the user is a non-primary participant."""
+    home, user1, user2 = db_home_with_users
+
+    template = QuestTemplate(
+        home_id=home.id,
+        title="Shared morning routine",
+        xp_reward=10,
+        gold_reward=5,
+        created_by=user1.id,
+    )
+    db.add(template)
+    db.commit()
+    db.refresh(template)
+
+    subscription = UserTemplateSubscription(
+        user_id=user2.id,
+        quest_template_id=template.id,
+        recurrence="daily",
+        schedule=json.dumps({"type": "daily", "time": "08:00"}),
+        is_active=True,
+    )
+    db.add(subscription)
+
+    existing_quest = Quest(
+        home_id=home.id,
+        created_by=user1.id,
+        user_id=user1.id,
+        quest_template_id=template.id,
+        title=template.title,
+        xp_reward=template.xp_reward,
+        gold_reward=template.gold_reward,
+        recurrence="daily",
+        schedule=json.dumps({"type": "daily", "time": "08:00"}),
+        completed=False,
+    )
+    db.add(existing_quest)
+    db.flush()
+    db.add(QuestParticipant(quest_id=existing_quest.id, user_id=user1.id))
+    db.add(QuestParticipant(quest_id=existing_quest.id, user_id=user2.id))
+    db.commit()
+
+    mock_now = datetime(2026, 1, 27, 9, 0, tzinfo=timezone.utc)
+    with patch("app.services.recurring_quests.datetime") as mock_datetime:
+        mock_datetime.now.return_value = mock_now
+        mock_datetime.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
+
+        generate_due_quests(home.id, db)
+
+    quests = db.exec(select(Quest).where(Quest.quest_template_id == template.id)).all()
+    assert [quest.id for quest in quests] == [existing_quest.id]
 
 
 def test_generate_sets_due_date_from_template(db: Session, db_home_with_users):

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -71,6 +71,58 @@ def test_delete_user(client: TestClient, home_with_user):
     assert response.status_code == 404
 
 
+def test_delete_user_reassigns_shared_quest_primary(client: TestClient, db_home_with_users, auth_context):
+    """Deleting the legacy primary participant keeps shared quests assigned."""
+    home, user1, user2 = db_home_with_users
+    auth_context.set_user(user1.id, home.id)
+
+    create_response = client.post(
+        "/api/quests/standalone",
+        json={
+            "title": "Shared cleanup",
+            "participant_user_ids": [user1.id, user2.id],
+        },
+    )
+    quest_id = create_response.json()["id"]
+
+    response = client.delete(f"/api/users/{user1.id}")
+
+    assert response.status_code == 200
+
+    auth_context.set_user(user2.id, home.id)
+    quest_response = client.get(f"/api/quests/{quest_id}")
+
+    assert quest_response.status_code == 200
+    quest = quest_response.json()
+    assert quest["user_id"] == user2.id
+    assert quest["created_by"] == user2.id
+    assert [participant["user_id"] for participant in quest["participants"]] == [user2.id]
+
+
+def test_delete_user_removes_solo_participant_quest(client: TestClient, db_home_with_users, auth_context):
+    """Deleting the only participant removes the quest instead of leaving an orphan."""
+    home, user1, user2 = db_home_with_users
+    auth_context.set_user(user1.id, home.id)
+
+    create_response = client.post(
+        "/api/quests/standalone",
+        json={
+            "title": "Solo cleanup",
+            "participant_user_ids": [user1.id],
+        },
+    )
+    quest_id = create_response.json()["id"]
+
+    response = client.delete(f"/api/users/{user1.id}")
+
+    assert response.status_code == 200
+
+    auth_context.set_user(user2.id, home.id)
+    quest_response = client.get(f"/api/quests/{quest_id}")
+
+    assert quest_response.status_code == 404
+
+
 def test_get_home_users(client: TestClient):
     """Test retrieving all users in a home"""
     # Create home with first user

--- a/docs/current-architecture.md
+++ b/docs/current-architecture.md
@@ -1,6 +1,6 @@
 # Current Architecture
 
-Last verified: 2026-02-12
+Last verified: 2026-04-16
 
 ## Source of truth priority
 
@@ -17,13 +17,24 @@ Last verified: 2026-02-12
 ## Implemented gameplay systems
 
 - Quest templates and quest instances
+- Shared quest participants via `quest_participant`
 - Standalone quests, AI-scribe quests, random quest generation
 - Per-user template subscriptions (`/api/subscriptions/*`)
-- Daily bounty with 2x rewards
+- Per-user daily bounty with 3x gold on the user's quest share
 - Corruption debuff for overdue quests
 - Reward claims including consumables (XP boost, shield)
 - Achievement auto-award on quest completion
 - NFC/trigger quest completion route
+
+## Quest ownership and rewards
+
+- `quest.user_id` remains as the legacy primary participant for compatibility.
+- Multi-user participation is stored in `quest_participant` with one row per quest/user.
+- `quest.xp_reward` and `quest.gold_reward` are the base total quest rewards.
+- On completion, base XP/gold are split across participants, preserving integer totals with deterministic remainder assignment by user id.
+- Per-user effects are applied to each participant's share after splitting: daily bounty, corruption/shield, and XP boost.
+- Actual awarded XP/gold are stored on `quest_participant.xp_awarded` and `quest_participant.gold_awarded`.
+- Runtime schema compatibility creates/backfills `quest_participant` rows for existing quests from legacy `quest.user_id`.
 
 ## High-level API areas
 

--- a/docs/current-architecture.md
+++ b/docs/current-architecture.md
@@ -28,13 +28,16 @@ Last verified: 2026-04-16
 
 ## Quest ownership and rewards
 
-- `quest.user_id` remains as the legacy primary participant for compatibility.
+- `quest.user_id` remains as the legacy primary participant for compatibility. It is the first
+  participant selected at creation/update time, not the only assignee.
 - Multi-user participation is stored in `quest_participant` with one row per quest/user.
 - `quest.xp_reward` and `quest.gold_reward` are the base total quest rewards.
 - On completion, base XP/gold are split across participants, preserving integer totals with deterministic remainder assignment by user id.
 - Per-user effects are applied to each participant's share after splitting: daily bounty, corruption/shield, and XP boost.
 - Actual awarded XP/gold are stored on `quest_participant.xp_awarded` and `quest_participant.gold_awarded`.
 - Runtime schema compatibility creates/backfills `quest_participant` rows for existing quests from legacy `quest.user_id`.
+  Keep this idempotent compatibility code through the production rollout; remove it only in a later cleanup once
+  every deployed database has been backfilled.
 
 ## High-level API areas
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -124,6 +124,10 @@ flowchart LR
 
 ### Quest creation and edit flow
 
+`CreateQuestForm` owns the quest party selection and sends `participant_user_ids` for AI-scribe,
+random, and template-created quests. `EditQuestModal` can update the party for active existing
+quests; completed quests keep their participant rows so reward history remains stable.
+
 ```mermaid
 %%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#f9f4e8', 'primaryBorderColor': '#8d6b4f', 'lineColor': '#8d6b4f', 'fontFamily': 'Georgia, serif' }}}%%
 flowchart TD

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -124,9 +124,10 @@ flowchart LR
 
 ### Quest creation and edit flow
 
-`CreateQuestForm` owns the quest party selection and sends `participant_user_ids` for AI-scribe,
-random, and template-created quests. `EditQuestModal` can update the party for active existing
-quests; completed quests keep their participant rows so reward history remains stable.
+`CreateQuestForm` owns the quest participant selection and sends `participant_user_ids` for
+AI-scribe, random, and template-created quests. The UI labels a single participant as "Quest For"
+and multiple participants as "Quest Party". `EditQuestModal` can update the party for active
+existing quests; completed quests keep their participant rows so reward history remains stable.
 
 ```mermaid
 %%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#f9f4e8', 'primaryBorderColor': '#8d6b4f', 'lineColor': '#8d6b4f', 'fontFamily': 'Georgia, serif' }}}%%

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -125,8 +125,10 @@ flowchart LR
 ### Quest creation and edit flow
 
 `CreateQuestForm` owns the quest participant selection and sends `participant_user_ids` for
-AI-scribe, random, and template-created quests. The UI labels a single participant as "Quest For"
-and multiple participants as "Quest Party". `EditQuestModal` can update the party for active
+AI-scribe and random quests. The UI labels a single participant as "Quest For" and multiple
+participants as "Quest Party". Template default editing exposes "New Quest For/Party" inside
+`EditQuestModal` so that selection is tied to the quest instance created by "Save Defaults &
+Create Quest", not to the template itself. `EditQuestModal` can update the party for active
 existing quests; completed quests keep their participant rows so reward history remains stable.
 
 ```mermaid

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,8 @@
     "dev": "vite",
     "dev:cloudflare": "bun run scripts/cloudflareDev.ts",
     "build": "tsc && vite build",
+    "check": "bun run typecheck && bun run format:check && bun run build",
+    "fix": "bun run format",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "test:cloudflare": "bun test scripts/cloudflareTunnel.test.ts",

--- a/frontend/scripts/editQuestModalHelpers.test.ts
+++ b/frontend/scripts/editQuestModalHelpers.test.ts
@@ -33,6 +33,21 @@ describe("buildStandaloneQuestUpdateData", () => {
 
     expect(payload.due_in_hours).toBeNull();
   });
+
+  test("includes participant IDs when quest party is selected", () => {
+    const payload = buildStandaloneQuestUpdateData({
+      displayName: "The Kitchen Cleanse",
+      description: "Defeat the sink dragon",
+      selectedTags: ["Chores"],
+      baseXP: 30,
+      baseGold: 15,
+      dueInHours: "",
+      selectedParticipantIds: [2, 4],
+    });
+
+    expect(payload.user_id).toBe(2);
+    expect(payload.participant_user_ids).toEqual([2, 4]);
+  });
 });
 
 describe("toDueInHoursStateValue", () => {

--- a/frontend/src/components/CreateQuestForm.tsx
+++ b/frontend/src/components/CreateQuestForm.tsx
@@ -41,7 +41,9 @@ export default function CreateQuestForm({ token, onQuestCreated, onClose }: Crea
   const [selectedTemplate, setSelectedTemplate] = useState<QuestTemplate | null>(null);
   const [loadingTemplates, setLoadingTemplates] = useState(false);
   const [loadingUsers, setLoadingUsers] = useState(false);
-  const [selectedUserId, setSelectedUserId] = useState<number | null>(userId);
+  const [selectedParticipantIds, setSelectedParticipantIds] = useState<number[]>(
+    userId !== null ? [userId] : []
+  );
 
   const fetchTemplates = async (): Promise<QuestTemplate[] | null> => {
     setLoadingTemplates(true);
@@ -63,7 +65,7 @@ export default function CreateQuestForm({ token, onQuestCreated, onClose }: Crea
   }, [token]);
 
   useEffect(() => {
-    setSelectedUserId(userId);
+    setSelectedParticipantIds(userId !== null ? [userId] : []);
   }, [userId]);
 
   useEffect(() => {
@@ -75,9 +77,9 @@ export default function CreateQuestForm({ token, onQuestCreated, onClose }: Crea
         if (users.length > 0) {
           const defaultUser =
             userId !== null && users.some((user) => user.id === userId) ? userId : users[0].id;
-          setSelectedUserId((current) => current ?? defaultUser);
+          setSelectedParticipantIds((current) => (current.length > 0 ? current : [defaultUser]));
         } else {
-          setSelectedUserId(null);
+          setSelectedParticipantIds([]);
         }
       } catch (err) {
         console.error("Failed to fetch home users:", err);
@@ -96,8 +98,8 @@ export default function CreateQuestForm({ token, onQuestCreated, onClose }: Crea
       return;
     }
 
-    if (selectedUserId === null) {
-      setError("Select who this quest is for");
+    if (selectedParticipantIds.length === 0) {
+      setError("Select at least one participant");
       return;
     }
 
@@ -112,9 +114,10 @@ export default function CreateQuestForm({ token, onQuestCreated, onClose }: Crea
           ...(selectedTags.length > 0 && { tags: selectedTags.join(",") }),
           xp_reward: 25,
           gold_reward: 15,
+          participant_user_ids: selectedParticipantIds,
         },
         token,
-        selectedUserId,
+        selectedParticipantIds[0],
         skipAI
       );
 
@@ -135,8 +138,8 @@ export default function CreateQuestForm({ token, onQuestCreated, onClose }: Crea
   };
 
   const handleRandomQuest = async () => {
-    if (selectedUserId === null) {
-      setError("Select who this quest is for");
+    if (selectedParticipantIds.length === 0) {
+      setError("Select at least one participant");
       return;
     }
 
@@ -171,8 +174,8 @@ export default function CreateQuestForm({ token, onQuestCreated, onClose }: Crea
   const handleCreateFromTemplate = async (action: TemplateAction) => {
     if (!selectedTemplate) return;
 
-    if (selectedUserId === null) {
-      setError("Select who this quest is for");
+    if (selectedParticipantIds.length === 0) {
+      setError("Select at least one participant");
       return;
     }
 
@@ -187,7 +190,14 @@ export default function CreateQuestForm({ token, onQuestCreated, onClose }: Crea
       setError(null);
 
       try {
-        await api.quests.create({ quest_template_id: selectedTemplate.id }, token, selectedUserId);
+        await api.quests.create(
+          {
+            quest_template_id: selectedTemplate.id,
+            participant_user_ids: selectedParticipantIds,
+          },
+          token,
+          selectedParticipantIds[0]
+        );
         playSound("questActivate");
         onQuestCreated();
         onClose();
@@ -197,6 +207,14 @@ export default function CreateQuestForm({ token, onQuestCreated, onClose }: Crea
         setLoading(false);
       }
     }
+  };
+
+  const toggleParticipant = (participantId: number) => {
+    setSelectedParticipantIds((current) =>
+      current.includes(participantId)
+        ? current.filter((id) => id !== participantId)
+        : [...current, participantId]
+    );
   };
 
   return (
@@ -295,36 +313,49 @@ export default function CreateQuestForm({ token, onQuestCreated, onClose }: Crea
                 className="block text-sm uppercase tracking-wider mb-2 font-serif"
                 style={{ color: COLORS.gold }}
               >
-                Quest For
+                Quest Party
               </label>
               <div
-                className="rounded"
+                className="rounded p-3 flex flex-wrap gap-2"
                 style={{
                   backgroundColor: COLORS.black,
                   borderColor: COLORS.gold,
                   borderWidth: "2px",
                 }}
               >
-                <select
-                  value={selectedUserId ?? ""}
-                  onChange={(e) => setSelectedUserId(e.target.value ? parseInt(e.target.value, 10) : null)}
-                  className="w-full px-3 py-2 font-serif focus:outline-none transition-all"
-                  style={{
-                    backgroundColor: "transparent",
-                    color: COLORS.parchment,
-                  }}
-                  disabled={loading || loadingUsers}
-                >
-                  <option value="" disabled>
-                    {loadingUsers ? "Loading household members..." : "Select a household member"}
-                  </option>
-                  {homeUsers.map((member) => (
-                    <option key={member.id} value={member.id} style={{ color: COLORS.darkPanel }}>
-                      {member.username}
-                      {member.id === userId ? " (You)" : ""}
-                    </option>
-                  ))}
-                </select>
+                {loadingUsers && (
+                  <span className="font-serif text-sm" style={{ color: COLORS.parchment }}>
+                    Loading household members...
+                  </span>
+                )}
+                {!loadingUsers &&
+                  homeUsers.map((member) => {
+                    const selected = selectedParticipantIds.includes(member.id);
+                    return (
+                      <label
+                        key={member.id}
+                        className="inline-flex items-center gap-2 px-3 py-2 rounded-sm font-serif text-sm"
+                        style={{
+                          backgroundColor: selected ? "rgba(212, 175, 55, 0.25)" : "rgba(212, 175, 55, 0.08)",
+                          border: `1px solid ${selected ? COLORS.gold : COLORS.brown}`,
+                          color: selected ? COLORS.gold : COLORS.parchment,
+                          cursor: loading ? "not-allowed" : "pointer",
+                        }}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={selected}
+                          onChange={() => toggleParticipant(member.id)}
+                          disabled={loading}
+                          style={{ accentColor: COLORS.gold }}
+                        />
+                        <span>
+                          {member.username}
+                          {member.id === userId ? " (You)" : ""}
+                        </span>
+                      </label>
+                    );
+                  })}
               </div>
             </div>
 
@@ -581,7 +612,8 @@ export default function CreateQuestForm({ token, onQuestCreated, onClose }: Crea
           initialData={templateInitialData || undefined}
           token={token}
           skipAI={skipAI}
-          targetUserId={selectedUserId}
+          targetUserId={selectedParticipantIds[0] ?? null}
+          targetParticipantUserIds={selectedParticipantIds}
           createQuestOnSave={createQuestOnSave}
           onSave={async (result) => {
             const isTemplateDefaultsFlow =

--- a/frontend/src/components/CreateQuestForm.tsx
+++ b/frontend/src/components/CreateQuestForm.tsx
@@ -277,7 +277,9 @@ export default function CreateQuestForm({ token, onQuestCreated, onClose }: Crea
                   setMode("from-template");
                   setTitle("");
                   setSelectedTags([]);
-                  setSelectedParticipantIds(userId !== null ? [userId] : homeUsers[0] ? [homeUsers[0].id] : []);
+                  setSelectedParticipantIds(
+                    userId !== null ? [userId] : homeUsers[0] ? [homeUsers[0].id] : []
+                  );
                   setError(null);
                 }}
                 className="flex-1 py-2 px-3 font-serif font-semibold text-xs uppercase tracking-wider transition-all"
@@ -339,7 +341,9 @@ export default function CreateQuestForm({ token, onQuestCreated, onClose }: Crea
                           key={member.id}
                           className="inline-flex items-center gap-2 px-3 py-2 rounded-sm font-serif text-sm"
                           style={{
-                            backgroundColor: selected ? "rgba(212, 175, 55, 0.25)" : "rgba(212, 175, 55, 0.08)",
+                            backgroundColor: selected
+                              ? "rgba(212, 175, 55, 0.25)"
+                              : "rgba(212, 175, 55, 0.08)",
                             border: `1px solid ${selected ? COLORS.gold : COLORS.brown}`,
                             color: selected ? COLORS.gold : COLORS.parchment,
                             cursor: loading ? "not-allowed" : "pointer",

--- a/frontend/src/components/CreateQuestForm.tsx
+++ b/frontend/src/components/CreateQuestForm.tsx
@@ -277,6 +277,7 @@ export default function CreateQuestForm({ token, onQuestCreated, onClose }: Crea
                   setMode("from-template");
                   setTitle("");
                   setSelectedTags([]);
+                  setSelectedParticipantIds(userId !== null ? [userId] : homeUsers[0] ? [homeUsers[0].id] : []);
                   setError(null);
                 }}
                 className="flex-1 py-2 px-3 font-serif font-semibold text-xs uppercase tracking-wider transition-all"
@@ -309,56 +310,58 @@ export default function CreateQuestForm({ token, onQuestCreated, onClose }: Crea
               </div>
             )}
 
-            <div className="mb-6">
-              <label
-                className="block text-sm uppercase tracking-wider mb-2 font-serif"
-                style={{ color: COLORS.gold }}
-              >
-                {participantLabel}
-              </label>
-              <div
-                className="rounded p-3 flex flex-wrap gap-2"
-                style={{
-                  backgroundColor: COLORS.black,
-                  borderColor: COLORS.gold,
-                  borderWidth: "2px",
-                }}
-              >
-                {loadingUsers && (
-                  <span className="font-serif text-sm" style={{ color: COLORS.parchment }}>
-                    Loading household members...
-                  </span>
-                )}
-                {!loadingUsers &&
-                  homeUsers.map((member) => {
-                    const selected = selectedParticipantIds.includes(member.id);
-                    return (
-                      <label
-                        key={member.id}
-                        className="inline-flex items-center gap-2 px-3 py-2 rounded-sm font-serif text-sm"
-                        style={{
-                          backgroundColor: selected ? "rgba(212, 175, 55, 0.25)" : "rgba(212, 175, 55, 0.08)",
-                          border: `1px solid ${selected ? COLORS.gold : COLORS.brown}`,
-                          color: selected ? COLORS.gold : COLORS.parchment,
-                          cursor: loading ? "not-allowed" : "pointer",
-                        }}
-                      >
-                        <input
-                          type="checkbox"
-                          checked={selected}
-                          onChange={() => toggleParticipant(member.id)}
-                          disabled={loading}
-                          style={{ accentColor: COLORS.gold }}
-                        />
-                        <span>
-                          {member.username}
-                          {member.id === userId ? " (You)" : ""}
-                        </span>
-                      </label>
-                    );
-                  })}
+            {mode !== "from-template" && (
+              <div className="mb-6">
+                <label
+                  className="block text-sm uppercase tracking-wider mb-2 font-serif"
+                  style={{ color: COLORS.gold }}
+                >
+                  {participantLabel}
+                </label>
+                <div
+                  className="rounded p-3 flex flex-wrap gap-2"
+                  style={{
+                    backgroundColor: COLORS.black,
+                    borderColor: COLORS.gold,
+                    borderWidth: "2px",
+                  }}
+                >
+                  {loadingUsers && (
+                    <span className="font-serif text-sm" style={{ color: COLORS.parchment }}>
+                      Loading household members...
+                    </span>
+                  )}
+                  {!loadingUsers &&
+                    homeUsers.map((member) => {
+                      const selected = selectedParticipantIds.includes(member.id);
+                      return (
+                        <label
+                          key={member.id}
+                          className="inline-flex items-center gap-2 px-3 py-2 rounded-sm font-serif text-sm"
+                          style={{
+                            backgroundColor: selected ? "rgba(212, 175, 55, 0.25)" : "rgba(212, 175, 55, 0.08)",
+                            border: `1px solid ${selected ? COLORS.gold : COLORS.brown}`,
+                            color: selected ? COLORS.gold : COLORS.parchment,
+                            cursor: loading ? "not-allowed" : "pointer",
+                          }}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={selected}
+                            onChange={() => toggleParticipant(member.id)}
+                            disabled={loading}
+                            style={{ accentColor: COLORS.gold }}
+                          />
+                          <span>
+                            {member.username}
+                            {member.id === userId ? " (You)" : ""}
+                          </span>
+                        </label>
+                      );
+                    })}
+                </div>
               </div>
-            </div>
+            )}
 
             {mode === "ai-scribe" && (
               <form onSubmit={handleSubmit}>

--- a/frontend/src/components/CreateQuestForm.tsx
+++ b/frontend/src/components/CreateQuestForm.tsx
@@ -44,6 +44,7 @@ export default function CreateQuestForm({ token, onQuestCreated, onClose }: Crea
   const [selectedParticipantIds, setSelectedParticipantIds] = useState<number[]>(
     userId !== null ? [userId] : []
   );
+  const participantLabel = selectedParticipantIds.length > 1 ? "Quest Party" : "Quest For";
 
   const fetchTemplates = async (): Promise<QuestTemplate[] | null> => {
     setLoadingTemplates(true);
@@ -313,7 +314,7 @@ export default function CreateQuestForm({ token, onQuestCreated, onClose }: Crea
                 className="block text-sm uppercase tracking-wider mb-2 font-serif"
                 style={{ color: COLORS.gold }}
               >
-                Quest Party
+                {participantLabel}
               </label>
               <div
                 className="rounded p-3 flex flex-wrap gap-2"

--- a/frontend/src/components/EditQuestModal.tsx
+++ b/frontend/src/components/EditQuestModal.tsx
@@ -96,7 +96,14 @@ export default function EditQuestModal({
     return fallbackUserId !== null ? [fallbackUserId] : [];
   };
   const [selectedParticipantIds, setSelectedParticipantIds] = useState<number[]>(getInitialParticipantIds);
-  const participantLabel = selectedParticipantIds.length > 1 ? "Quest Party" : "Quest For";
+  const showParticipantSelector = Boolean(quest || isTemplateDefaultsMode);
+  const participantLabel = isTemplateDefaultsMode
+    ? selectedParticipantIds.length > 1
+      ? "New Quest Party"
+      : "New Quest For"
+    : selectedParticipantIds.length > 1
+      ? "Quest Party"
+      : "Quest For";
 
   // Recurring quest fields
   const [recurrence, setRecurrence] = useState<QuestRecurrence>("one-off");
@@ -590,7 +597,7 @@ export default function EditQuestModal({
                 </div>
               )}
 
-              {quest && (
+              {showParticipantSelector && (
                 <div className="mb-6">
                   <label
                     className="block text-sm uppercase tracking-wider mb-2 font-serif"
@@ -621,14 +628,14 @@ export default function EditQuestModal({
                             backgroundColor: selected ? "rgba(212, 175, 55, 0.25)" : "rgba(212, 175, 55, 0.08)",
                             border: `1px solid ${selected ? COLORS.gold : COLORS.brown}`,
                             color: selected ? COLORS.gold : COLORS.parchment,
-                            cursor: saving || quest.completed ? "not-allowed" : "pointer",
+                            cursor: saving || quest?.completed ? "not-allowed" : "pointer",
                           }}
                         >
                           <input
                             type="checkbox"
                             checked={selected}
                             onChange={() => toggleParticipant(member.id)}
-                            disabled={saving || quest.completed}
+                            disabled={saving || quest?.completed}
                             style={{ accentColor: COLORS.gold }}
                           />
                           <span>
@@ -639,7 +646,7 @@ export default function EditQuestModal({
                       );
                     })}
                   </div>
-                  {quest.completed && (
+                  {quest?.completed && (
                     <p className="mt-2 text-xs font-serif italic" style={{ color: COLORS.parchment }}>
                       Completed quests keep their current party so rewards and history stay consistent.
                     </p>

--- a/frontend/src/components/EditQuestModal.tsx
+++ b/frontend/src/components/EditQuestModal.tsx
@@ -96,6 +96,7 @@ export default function EditQuestModal({
     return fallbackUserId !== null ? [fallbackUserId] : [];
   };
   const [selectedParticipantIds, setSelectedParticipantIds] = useState<number[]>(getInitialParticipantIds);
+  const participantLabel = selectedParticipantIds.length > 1 ? "Quest Party" : "Quest For";
 
   // Recurring quest fields
   const [recurrence, setRecurrence] = useState<QuestRecurrence>("one-off");
@@ -595,7 +596,7 @@ export default function EditQuestModal({
                     className="block text-sm uppercase tracking-wider mb-2 font-serif"
                     style={{ color: COLORS.gold }}
                   >
-                    Quest Party
+                    {participantLabel}
                   </label>
                   <div
                     className="rounded p-3 flex flex-wrap gap-2"

--- a/frontend/src/components/EditQuestModal.tsx
+++ b/frontend/src/components/EditQuestModal.tsx
@@ -95,7 +95,8 @@ export default function EditQuestModal({
     const fallbackUserId = targetUserId ?? userId;
     return fallbackUserId !== null ? [fallbackUserId] : [];
   };
-  const [selectedParticipantIds, setSelectedParticipantIds] = useState<number[]>(getInitialParticipantIds);
+  const [selectedParticipantIds, setSelectedParticipantIds] =
+    useState<number[]>(getInitialParticipantIds);
   const showParticipantSelector = Boolean(quest || isTemplateDefaultsMode);
   const participantLabel = isTemplateDefaultsMode
     ? selectedParticipantIds.length > 1
@@ -625,7 +626,9 @@ export default function EditQuestModal({
                           key={member.id}
                           className="inline-flex items-center gap-2 px-3 py-2 rounded-sm font-serif text-sm"
                           style={{
-                            backgroundColor: selected ? "rgba(212, 175, 55, 0.25)" : "rgba(212, 175, 55, 0.08)",
+                            backgroundColor: selected
+                              ? "rgba(212, 175, 55, 0.25)"
+                              : "rgba(212, 175, 55, 0.08)",
                             border: `1px solid ${selected ? COLORS.gold : COLORS.brown}`,
                             color: selected ? COLORS.gold : COLORS.parchment,
                             cursor: saving || quest?.completed ? "not-allowed" : "pointer",
@@ -647,8 +650,12 @@ export default function EditQuestModal({
                     })}
                   </div>
                   {quest?.completed && (
-                    <p className="mt-2 text-xs font-serif italic" style={{ color: COLORS.parchment }}>
-                      Completed quests keep their current party so rewards and history stay consistent.
+                    <p
+                      className="mt-2 text-xs font-serif italic"
+                      style={{ color: COLORS.parchment }}
+                    >
+                      Completed quests keep their current party so rewards and history stay
+                      consistent.
                     </p>
                   )}
                 </div>

--- a/frontend/src/components/EditQuestModal.tsx
+++ b/frontend/src/components/EditQuestModal.tsx
@@ -41,6 +41,7 @@ interface EditQuestModalProps {
   token: string;
   skipAI: boolean;
   targetUserId?: number | null;
+  targetParticipantUserIds?: number[];
   createQuestOnSave?: boolean; // If true, creates quest on save (for template/initialData modes)
   onSave?: (result: {
     createdQuest: boolean;
@@ -57,6 +58,7 @@ export default function EditQuestModal({
   token,
   skipAI,
   targetUserId,
+  targetParticipantUserIds,
   createQuestOnSave = false,
   onSave,
   onClose,
@@ -85,7 +87,15 @@ export default function EditQuestModal({
   const [originalRecurrence, setOriginalRecurrence] = useState<QuestRecurrence>("one-off");
   const [saveAsTemplate, setSaveAsTemplate] = useState(false);
   const [homeUsers, setHomeUsers] = useState<User[]>([]);
-  const [selectedUserId, setSelectedUserId] = useState<number | null>(targetUserId ?? userId);
+  const getInitialParticipantIds = () => {
+    if (targetParticipantUserIds && targetParticipantUserIds.length > 0) {
+      return targetParticipantUserIds;
+    }
+
+    const fallbackUserId = targetUserId ?? userId;
+    return fallbackUserId !== null ? [fallbackUserId] : [];
+  };
+  const [selectedParticipantIds, setSelectedParticipantIds] = useState<number[]>(getInitialParticipantIds);
 
   // Recurring quest fields
   const [recurrence, setRecurrence] = useState<QuestRecurrence>("one-off");
@@ -109,9 +119,9 @@ export default function EditQuestModal({
 
   useEffect(() => {
     if (!questId) {
-      setSelectedUserId(targetUserId ?? userId);
+      setSelectedParticipantIds(getInitialParticipantIds());
     }
-  }, [questId, targetUserId, userId]);
+  }, [questId, targetParticipantUserIds, targetUserId, userId]);
 
   // Load data based on mode
   useEffect(() => {
@@ -235,7 +245,11 @@ export default function EditQuestModal({
           setDueInHours(toDueInHoursStateValue(response.due_in_hours));
 
           setQuest(response);
-          setSelectedUserId(response.user_id);
+          setSelectedParticipantIds(
+            response.participants && response.participants.length > 0
+              ? response.participants.map((participant) => participant.user_id)
+              : [response.user_id]
+          );
           setLoading(false);
 
           if (response.display_name || response.description) {
@@ -281,12 +295,13 @@ export default function EditQuestModal({
               xp_reward: baseXP,
               gold_reward: baseGold,
               ...(dueInHours && { due_in_hours: parseInt(dueInHours) }),
+              participant_user_ids: selectedParticipantIds,
             };
 
             const createdQuest = await api.quests.createAIScribe(
               questData,
               token,
-              targetUserId ?? userId,
+              selectedParticipantIds[0] ?? targetUserId ?? userId,
               true
             ); // skip_ai=true
 
@@ -306,9 +321,12 @@ export default function EditQuestModal({
           } else if (templateId) {
             // From template create mode - create quest from current template defaults
             const createdQuest = await api.quests.create(
-              { quest_template_id: templateId },
+              {
+                quest_template_id: templateId,
+                participant_user_ids: selectedParticipantIds,
+              },
               token,
-              targetUserId ?? userId
+              selectedParticipantIds[0] ?? targetUserId ?? userId
             );
             onSave?.({ createdQuest: true, updatedTemplateDefaults: false, quest: createdQuest });
           }
@@ -362,7 +380,14 @@ export default function EditQuestModal({
             if (userId === null) {
               throw new Error("User ID not found in session");
             }
-            await api.quests.create({ quest_template_id: templateId }, token, targetUserId ?? userId);
+            await api.quests.create(
+              {
+                quest_template_id: templateId,
+                participant_user_ids: selectedParticipantIds,
+              },
+              token,
+              selectedParticipantIds[0] ?? targetUserId ?? userId
+            );
           }
 
           onSave?.({
@@ -372,8 +397,8 @@ export default function EditQuestModal({
           // Don't call onClose - parent's onSave callback handles closing
         } else if (quest) {
           // EDIT QUEST MODE: Update existing quest
-          if (selectedUserId === null) {
-            throw new Error("Select who this quest is for");
+          if (selectedParticipantIds.length === 0) {
+            throw new Error("Select at least one participant");
           }
 
           const updateData = buildStandaloneQuestUpdateData({
@@ -383,7 +408,7 @@ export default function EditQuestModal({
             baseXP,
             baseGold,
             dueInHours,
-            selectedUserId,
+            selectedParticipantIds,
           });
 
           const updatedQuest = await api.quests.update(quest.id, updateData, token);
@@ -429,10 +454,11 @@ export default function EditQuestModal({
       scheduleDay,
       scheduleDayOfMonth,
       dueInHours,
-      selectedUserId,
+      selectedParticipantIds,
       token,
       userId,
       targetUserId,
+      targetParticipantUserIds,
       onSave,
       onClose,
     ]
@@ -446,6 +472,14 @@ export default function EditQuestModal({
     if (!saving && !loading) {
       handleSave();
     }
+  };
+
+  const toggleParticipant = (participantId: number) => {
+    setSelectedParticipantIds((current) =>
+      current.includes(participantId)
+        ? current.filter((id) => id !== participantId)
+        : [...current, participantId]
+    );
   };
 
   return (
@@ -561,42 +595,52 @@ export default function EditQuestModal({
                     className="block text-sm uppercase tracking-wider mb-2 font-serif"
                     style={{ color: COLORS.gold }}
                   >
-                    Quest For
+                    Quest Party
                   </label>
                   <div
-                    className="rounded"
+                    className="rounded p-3 flex flex-wrap gap-2"
                     style={{
                       backgroundColor: COLORS.black,
                       borderColor: COLORS.gold,
                       borderWidth: "2px",
                     }}
                   >
-                    <select
-                      value={selectedUserId ?? ""}
-                      onChange={(e) =>
-                        setSelectedUserId(e.target.value ? parseInt(e.target.value, 10) : null)
-                      }
-                      className="w-full px-3 py-2 font-serif focus:outline-none transition-all"
-                      style={{
-                        backgroundColor: "transparent",
-                        color: COLORS.parchment,
-                      }}
-                      disabled={saving || quest.completed}
-                    >
-                      <option value="" disabled>
-                        {homeUsers.length > 0 ? "Select a household member" : "Loading household members..."}
-                      </option>
-                      {homeUsers.map((member) => (
-                        <option key={member.id} value={member.id} style={{ color: COLORS.darkPanel }}>
-                          {member.username}
-                          {member.id === userId ? " (You)" : ""}
-                        </option>
-                      ))}
-                    </select>
+                    {homeUsers.length === 0 && (
+                      <span className="font-serif text-sm" style={{ color: COLORS.parchment }}>
+                        Loading household members...
+                      </span>
+                    )}
+                    {homeUsers.map((member) => {
+                      const selected = selectedParticipantIds.includes(member.id);
+                      return (
+                        <label
+                          key={member.id}
+                          className="inline-flex items-center gap-2 px-3 py-2 rounded-sm font-serif text-sm"
+                          style={{
+                            backgroundColor: selected ? "rgba(212, 175, 55, 0.25)" : "rgba(212, 175, 55, 0.08)",
+                            border: `1px solid ${selected ? COLORS.gold : COLORS.brown}`,
+                            color: selected ? COLORS.gold : COLORS.parchment,
+                            cursor: saving || quest.completed ? "not-allowed" : "pointer",
+                          }}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={selected}
+                            onChange={() => toggleParticipant(member.id)}
+                            disabled={saving || quest.completed}
+                            style={{ accentColor: COLORS.gold }}
+                          />
+                          <span>
+                            {member.username}
+                            {member.id === userId ? " (You)" : ""}
+                          </span>
+                        </label>
+                      );
+                    })}
                   </div>
                   {quest.completed && (
                     <p className="mt-2 text-xs font-serif italic" style={{ color: COLORS.parchment }}>
-                      Completed quests keep their current owner so rewards and history stay consistent.
+                      Completed quests keep their current party so rewards and history stay consistent.
                     </p>
                   )}
                 </div>

--- a/frontend/src/components/QuestCard.tsx
+++ b/frontend/src/components/QuestCard.tsx
@@ -77,7 +77,10 @@ export default function QuestCard({
       : quest.xp_reward || 0;
   const completedGoldTotal =
     quest.completed && quest.participants?.some((participant) => participant.gold_awarded !== null)
-      ? quest.participants.reduce((total, participant) => total + (participant.gold_awarded ?? 0), 0)
+      ? quest.participants.reduce(
+          (total, participant) => total + (participant.gold_awarded ?? 0),
+          0
+        )
       : quest.gold_reward || 0;
   const displayXpReward = quest.completed ? completedXpTotal : quest.xp_reward || 0;
   const displayGoldReward =
@@ -273,7 +276,8 @@ export default function QuestCard({
         <div className="mb-6 md:mb-8 flex flex-wrap gap-3 text-xs font-serif uppercase tracking-wide">
           {questParticipantNames && (
             <span style={{ color: COLORS.brown }}>
-              {participantLabel}: <span style={{ color: COLORS.gold }}>{questParticipantNames}</span>
+              {participantLabel}:{" "}
+              <span style={{ color: COLORS.gold }}>{questParticipantNames}</span>
             </span>
           )}
           {questCreatorName && !questParticipantNames?.split(", ").includes(questCreatorName) && (

--- a/frontend/src/components/QuestCard.tsx
+++ b/frontend/src/components/QuestCard.tsx
@@ -39,7 +39,7 @@ const getQuestTypeStyles = (questType: string): QuestTypeStyles => {
 
 interface QuestCardProps {
   quest: Quest;
-  questOwnerName?: string;
+  questParticipantNames?: string;
   questCreatorName?: string;
   onComplete: (questId: number) => void;
   onAbandon?: (questId: number) => void;
@@ -51,7 +51,7 @@ interface QuestCardProps {
 
 export default function QuestCard({
   quest,
-  questOwnerName,
+  questParticipantNames,
   questCreatorName,
   onComplete,
   onAbandon,
@@ -69,6 +69,22 @@ export default function QuestCard({
   );
   const [showOriginalTitle, setShowOriginalTitle] = useState(false);
   const originalTitlePanelId = `quest-original-title-${quest.id}`;
+  const participantCount = quest.participants?.length || 1;
+  const completedXpTotal =
+    quest.completed && quest.participants?.some((participant) => participant.xp_awarded !== null)
+      ? quest.participants.reduce((total, participant) => total + (participant.xp_awarded ?? 0), 0)
+      : quest.xp_reward || 0;
+  const completedGoldTotal =
+    quest.completed && quest.participants?.some((participant) => participant.gold_awarded !== null)
+      ? quest.participants.reduce((total, participant) => total + (participant.gold_awarded ?? 0), 0)
+      : quest.gold_reward || 0;
+  const displayXpReward = quest.completed ? completedXpTotal : quest.xp_reward || 0;
+  const displayGoldReward =
+    isDailyBounty && !quest.completed && participantCount === 1
+      ? (quest.gold_reward || 0) * 3
+      : quest.completed
+        ? completedGoldTotal
+        : quest.gold_reward || 0;
 
   useEffect(() => {
     setShowOriginalTitle(false);
@@ -252,14 +268,14 @@ export default function QuestCard({
         {quest.description || "No description"}
       </p>
 
-      {(questOwnerName || questCreatorName) && (
+      {(questParticipantNames || questCreatorName) && (
         <div className="mb-6 md:mb-8 flex flex-wrap gap-3 text-xs font-serif uppercase tracking-wide">
-          {questOwnerName && (
+          {questParticipantNames && (
             <span style={{ color: COLORS.brown }}>
-              For: <span style={{ color: COLORS.gold }}>{questOwnerName}</span>
+              Party: <span style={{ color: COLORS.gold }}>{questParticipantNames}</span>
             </span>
           )}
-          {questCreatorName && questCreatorName !== questOwnerName && (
+          {questCreatorName && !questParticipantNames?.split(", ").includes(questCreatorName) && (
             <span style={{ color: COLORS.brown }}>
               Created by: <span style={{ color: COLORS.parchment }}>{questCreatorName}</span>
             </span>
@@ -296,29 +312,41 @@ export default function QuestCard({
             className="text-xs uppercase tracking-widest mb-2 font-serif"
             style={{ color: COLORS.brown }}
           >
-            XP Reward
+            {quest.completed ? "XP Awarded" : "XP Reward"}
           </div>
           <div className="text-2xl md:text-3xl font-serif font-bold" style={{ color: COLORS.gold }}>
-            {quest.xp_reward || 0}
+            {displayXpReward}
           </div>
+          {participantCount > 1 && (
+            <div className="mt-1 text-xs font-serif" style={{ color: COLORS.brown }}>
+              {quest.completed ? "Awarded across party" : `Split ${participantCount} ways`}
+            </div>
+          )}
         </div>
         <div className="text-center flex-1">
           <div
             className="text-xs uppercase tracking-widest mb-2 font-serif"
             style={{ color: COLORS.brown }}
           >
-            Gold Reward
+            {quest.completed ? "Gold Awarded" : "Gold Reward"}
           </div>
           <div className="text-2xl md:text-3xl font-serif font-bold" style={{ color: COLORS.gold }}>
-            {isDailyBounty && !quest.completed
-              ? (quest.gold_reward || 0) * 3
-              : quest.gold_reward || 0}
-            {isDailyBounty && !quest.completed && (
+            {displayGoldReward}
+            {isDailyBounty && !quest.completed && participantCount === 1 && (
               <span className="text-sm ml-2" style={{ color: "#9d84ff" }}>
                 (3x)
               </span>
             )}
           </div>
+          {participantCount > 1 && (
+            <div className="mt-1 text-xs font-serif" style={{ color: COLORS.brown }}>
+              {quest.completed
+                ? "Awarded across party"
+                : isDailyBounty
+                  ? "Split; bounty multiplies your share"
+                  : `Split ${participantCount} ways`}
+            </div>
+          )}
         </div>
         <div className="text-center flex-1">
           <div

--- a/frontend/src/components/QuestCard.tsx
+++ b/frontend/src/components/QuestCard.tsx
@@ -70,6 +70,7 @@ export default function QuestCard({
   const [showOriginalTitle, setShowOriginalTitle] = useState(false);
   const originalTitlePanelId = `quest-original-title-${quest.id}`;
   const participantCount = quest.participants?.length || 1;
+  const participantLabel = participantCount > 1 ? "Party" : "For";
   const completedXpTotal =
     quest.completed && quest.participants?.some((participant) => participant.xp_awarded !== null)
       ? quest.participants.reduce((total, participant) => total + (participant.xp_awarded ?? 0), 0)
@@ -272,7 +273,7 @@ export default function QuestCard({
         <div className="mb-6 md:mb-8 flex flex-wrap gap-3 text-xs font-serif uppercase tracking-wide">
           {questParticipantNames && (
             <span style={{ color: COLORS.brown }}>
-              Party: <span style={{ color: COLORS.gold }}>{questParticipantNames}</span>
+              {participantLabel}: <span style={{ color: COLORS.gold }}>{questParticipantNames}</span>
             </span>
           )}
           {questCreatorName && !questParticipantNames?.split(", ").includes(questCreatorName) && (

--- a/frontend/src/components/editQuestModalHelpers.ts
+++ b/frontend/src/components/editQuestModalHelpers.ts
@@ -5,7 +5,7 @@ interface StandaloneQuestUpdateDataInput {
   baseXP: number;
   baseGold: number;
   dueInHours: string;
-  selectedUserId?: number | null;
+  selectedParticipantIds?: number[];
 }
 
 interface StandaloneQuestUpdateData {
@@ -16,6 +16,7 @@ interface StandaloneQuestUpdateData {
   gold_reward: number;
   due_in_hours: number | null;
   user_id?: number;
+  participant_user_ids?: number[];
 }
 
 interface DifficultySliders {
@@ -50,8 +51,10 @@ export function buildStandaloneQuestUpdateData({
   baseXP,
   baseGold,
   dueInHours,
-  selectedUserId,
+  selectedParticipantIds,
 }: StandaloneQuestUpdateDataInput): StandaloneQuestUpdateData {
+  const participantIds = selectedParticipantIds ?? [];
+
   return {
     ...(displayName.trim() && { display_name: displayName.trim() }),
     ...(description.trim() && { description: description.trim() }),
@@ -59,7 +62,10 @@ export function buildStandaloneQuestUpdateData({
     xp_reward: baseXP,
     gold_reward: baseGold,
     due_in_hours: dueInHours ? parseInt(dueInHours, 10) : null,
-    ...(selectedUserId !== null && selectedUserId !== undefined && { user_id: selectedUserId }),
+    ...(participantIds.length > 0 && {
+      user_id: participantIds[0],
+      participant_user_ids: participantIds,
+    }),
   };
 }
 

--- a/frontend/src/pages/Board.tsx
+++ b/frontend/src/pages/Board.tsx
@@ -33,6 +33,8 @@ function CompactQuestCard({
   isDailyBounty = false,
   onClick,
 }: CompactQuestCardProps) {
+  const participantLabel = (quest.participants?.length || 1) > 1 ? "Party" : "For";
+
   return (
     <button
       type="button"
@@ -71,7 +73,7 @@ function CompactQuestCard({
 
       {questParticipantNames && (
         <div className="mb-3 text-[11px] sm:text-xs font-serif uppercase tracking-wide">
-          <span style={{ color: COLORS.brown }}>Party:</span>{" "}
+          <span style={{ color: COLORS.brown }}>{participantLabel}:</span>{" "}
           <span style={{ color: COLORS.gold }}>{questParticipantNames}</span>
         </div>
       )}

--- a/frontend/src/pages/Board.tsx
+++ b/frontend/src/pages/Board.tsx
@@ -150,7 +150,11 @@ const getQuestParticipantNames = (quest: Quest, homeUsers: Record<number, string
     .map((participantUserId) => homeUsers[participantUserId])
     .filter(Boolean)
     .join(", ");
-const matchesQuestSearch = (quest: Quest, participantNames: string | undefined, searchTerm: string) => {
+const matchesQuestSearch = (
+  quest: Quest,
+  participantNames: string | undefined,
+  searchTerm: string
+) => {
   const normalizedSearch = searchTerm.trim().toLowerCase();
   if (!normalizedSearch) return true;
 
@@ -400,8 +404,9 @@ export default function Board() {
   const splitIntegerReward = (total: number, participantCount: number): number[] => {
     const baseShare = Math.floor(total / participantCount);
     const remainder = total % participantCount;
-    return Array.from({ length: participantCount }, (_, index) =>
-      baseShare + (index < remainder ? 1 : 0)
+    return Array.from(
+      { length: participantCount },
+      (_, index) => baseShare + (index < remainder ? 1 : 0)
     );
   };
   const getQuestRewardShare = (quest: Quest, participantUserId: number, reward: "xp" | "gold") => {
@@ -415,11 +420,11 @@ export default function Board() {
   const activeBountyXpShare =
     activeBountyQuest && userId !== null
       ? getQuestRewardShare(activeBountyQuest, userId, "xp")
-      : activeBountyQuest?.xp_reward ?? 0;
+      : (activeBountyQuest?.xp_reward ?? 0);
   const activeBountyGoldShare =
     activeBountyQuest && userId !== null
       ? getQuestRewardShare(activeBountyQuest, userId, "gold")
-      : activeBountyQuest?.gold_reward ?? 0;
+      : (activeBountyQuest?.gold_reward ?? 0);
   const fullUpcomingQuests = useMemo(() => upcomingQuests.map(toUpcomingQuest), [upcomingQuests]);
   const filteredCurrentQuests = useMemo(
     () =>
@@ -459,13 +464,19 @@ export default function Board() {
 
   const pagedCurrentQuests = useMemo(
     () =>
-      filteredCurrentQuests.slice(currentPage * QUESTS_PER_PAGE, (currentPage + 1) * QUESTS_PER_PAGE),
+      filteredCurrentQuests.slice(
+        currentPage * QUESTS_PER_PAGE,
+        (currentPage + 1) * QUESTS_PER_PAGE
+      ),
     [filteredCurrentQuests, currentPage]
   );
 
   const pagedUpcomingQuests = useMemo(
     () =>
-      filteredUpcomingQuests.slice(upcomingPage * QUESTS_PER_PAGE, (upcomingPage + 1) * QUESTS_PER_PAGE),
+      filteredUpcomingQuests.slice(
+        upcomingPage * QUESTS_PER_PAGE,
+        (upcomingPage + 1) * QUESTS_PER_PAGE
+      ),
     [filteredUpcomingQuests, upcomingPage]
   );
   const currentPageCount = getPageCount(filteredCurrentQuests);
@@ -542,7 +553,9 @@ export default function Board() {
       }
     } catch {
       if (updatedQuest) {
-        setQuests((prev) => prev.map((quest) => (quest.id === updatedQuest.id ? updatedQuest : quest)));
+        setQuests((prev) =>
+          prev.map((quest) => (quest.id === updatedQuest.id ? updatedQuest : quest))
+        );
       }
     }
   };
@@ -687,9 +700,7 @@ export default function Board() {
             </p>
             <div className="flex flex-wrap items-center justify-between gap-4">
               <div className="flex gap-6 text-sm font-serif" style={{ color: COLORS.gold }}>
-                <span>
-                  Your XP: {activeBountyXpShare}
-                </span>
+                <span>Your XP: {activeBountyXpShare}</span>
                 <span>
                   Your Gold: {activeBountyGoldShare} x3 = {activeBountyGoldShare * 3}
                 </span>
@@ -710,154 +721,156 @@ export default function Board() {
       )}
 
       {!loading && hasBoardContent && (
-          <div className="mb-6">
-            <div
-              className="relative rounded-lg overflow-hidden p-4 sm:p-6"
-              style={{
-                backgroundImage: `linear-gradient(rgba(12, 8, 6, 0.42), rgba(12, 8, 6, 0.42)), url(${boardBackground})`,
-                backgroundSize: "cover",
-                backgroundPosition: "center",
-                border: `2px solid ${COLORS.brown}`,
-                minHeight: "520px",
-              }}
-            >
-              <div className="flex items-center justify-between mb-3">
-                <h3
-                  className="font-serif uppercase text-sm tracking-widest"
-                  style={{ color: COLORS.gold }}
-                >
-                  {view === "current" ? "Quest Board" : "Upcoming Board"}
-                </h3>
-                <div className="font-serif text-xs" style={{ color: COLORS.parchment }}>
-                  Page {activePage + 1} / {activePageCount}
-                </div>
+        <div className="mb-6">
+          <div
+            className="relative rounded-lg overflow-hidden p-4 sm:p-6"
+            style={{
+              backgroundImage: `linear-gradient(rgba(12, 8, 6, 0.42), rgba(12, 8, 6, 0.42)), url(${boardBackground})`,
+              backgroundSize: "cover",
+              backgroundPosition: "center",
+              border: `2px solid ${COLORS.brown}`,
+              minHeight: "520px",
+            }}
+          >
+            <div className="flex items-center justify-between mb-3">
+              <h3
+                className="font-serif uppercase text-sm tracking-widest"
+                style={{ color: COLORS.gold }}
+              >
+                {view === "current" ? "Quest Board" : "Upcoming Board"}
+              </h3>
+              <div className="font-serif text-xs" style={{ color: COLORS.parchment }}>
+                Page {activePage + 1} / {activePageCount}
               </div>
+            </div>
 
-              <div className="mb-4">
-                <div className="relative">
-                  <input
-                    type="text"
-                    value={view === "current" ? currentSearchTerm : upcomingSearchTerm}
-                    onChange={(event) =>
-                      view === "current"
-                        ? setCurrentSearchTerm(event.target.value)
-                        : setUpcomingSearchTerm(event.target.value)
+            <div className="mb-4">
+              <div className="relative">
+                <input
+                  type="text"
+                  value={view === "current" ? currentSearchTerm : upcomingSearchTerm}
+                  onChange={(event) =>
+                    view === "current"
+                      ? setCurrentSearchTerm(event.target.value)
+                      : setUpcomingSearchTerm(event.target.value)
+                  }
+                  placeholder={
+                    view === "current"
+                      ? "Search quests by title, description, tag, or person..."
+                      : "Search upcoming quests by title, description, tag, or person..."
+                  }
+                  aria-label={
+                    view === "current" ? "Search current quests" : "Search upcoming quests"
+                  }
+                  className="w-full px-3 py-2 pr-10 font-serif focus:outline-none focus:shadow-lg transition-all"
+                  style={{
+                    backgroundColor: COLORS.black,
+                    borderColor: COLORS.gold,
+                    borderWidth: "2px",
+                    color: COLORS.parchment,
+                  }}
+                />
+                {activeSearchTerm && (
+                  <button
+                    type="button"
+                    onClick={() =>
+                      view === "current" ? setCurrentSearchTerm("") : setUpcomingSearchTerm("")
                     }
-                    placeholder={
-                      view === "current"
-                        ? "Search quests by title, description, tag, or person..."
-                        : "Search upcoming quests by title, description, tag, or person..."
-                    }
-                    aria-label={view === "current" ? "Search current quests" : "Search upcoming quests"}
-                    className="w-full px-3 py-2 pr-10 font-serif focus:outline-none focus:shadow-lg transition-all"
-                    style={{
-                      backgroundColor: COLORS.black,
-                      borderColor: COLORS.gold,
-                      borderWidth: "2px",
-                      color: COLORS.parchment,
-                    }}
-                  />
-                  {activeSearchTerm && (
-                    <button
-                      type="button"
-                      onClick={() =>
-                        view === "current" ? setCurrentSearchTerm("") : setUpcomingSearchTerm("")
-                      }
-                      className="absolute right-2 top-1/2 -translate-y-1/2 text-sm font-serif"
-                      style={{ color: COLORS.gold }}
-                      aria-label="Clear quest search"
-                    >
-                      ✕
-                    </button>
-                  )}
-                </div>
-                <div className="mt-2 text-xs font-serif" style={{ color: COLORS.goldDarker }}>
-                  {view === "current" ? currentSearchLabel : upcomingSearchLabel}
-                </div>
-              </div>
-
-              {(view === "current" && pagedCurrentQuests.length > 0) ||
-              (view === "upcoming" && pagedUpcomingQuests.length > 0) ? (
-                <AnimatePresence mode="wait" initial={false}>
-                  <motion.div
-                    key={`${view}-${activePage}`}
-                    initial={{ opacity: 0, x: 30 * pageDirection }}
-                    animate={{ opacity: 1, x: 0 }}
-                    exit={{ opacity: 0, x: -30 * pageDirection }}
-                    transition={{ duration: 0.22, ease: "easeOut" }}
-                    className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4"
+                    className="absolute right-2 top-1/2 -translate-y-1/2 text-sm font-serif"
+                    style={{ color: COLORS.gold }}
+                    aria-label="Clear quest search"
                   >
-                    {view === "current" &&
-                      pagedCurrentQuests.map((quest) => (
+                    ✕
+                  </button>
+                )}
+              </div>
+              <div className="mt-2 text-xs font-serif" style={{ color: COLORS.goldDarker }}>
+                {view === "current" ? currentSearchLabel : upcomingSearchLabel}
+              </div>
+            </div>
+
+            {(view === "current" && pagedCurrentQuests.length > 0) ||
+            (view === "upcoming" && pagedUpcomingQuests.length > 0) ? (
+              <AnimatePresence mode="wait" initial={false}>
+                <motion.div
+                  key={`${view}-${activePage}`}
+                  initial={{ opacity: 0, x: 30 * pageDirection }}
+                  animate={{ opacity: 1, x: 0 }}
+                  exit={{ opacity: 0, x: -30 * pageDirection }}
+                  transition={{ duration: 0.22, ease: "easeOut" }}
+                  className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4"
+                >
+                  {view === "current" &&
+                    pagedCurrentQuests.map((quest) => (
+                      <CompactQuestCard
+                        key={quest.id}
+                        quest={quest}
+                        questParticipantNames={getQuestParticipantNames(quest, homeUsers)}
+                        isDailyBounty={activeBountyQuest?.id === quest.id}
+                        onClick={() => openQuestDetails(quest, "current")}
+                      />
+                    ))}
+
+                  {view === "upcoming" &&
+                    pagedUpcomingQuests.map((quest) => {
+                      const upcoming = upcomingQuests.find((item) => item.id === quest.id);
+                      return (
                         <CompactQuestCard
                           key={quest.id}
                           quest={quest}
                           questParticipantNames={getQuestParticipantNames(quest, homeUsers)}
-                          isDailyBounty={activeBountyQuest?.id === quest.id}
-                          onClick={() => openQuestDetails(quest, "current")}
+                          isUpcoming={true}
+                          onClick={() =>
+                            openQuestDetails(quest, "upcoming", upcoming?.next_spawn_at)
+                          }
                         />
-                      ))}
+                      );
+                    })}
+                </motion.div>
+              </AnimatePresence>
+            ) : (
+              <div className="py-16 text-center font-serif" style={{ color: COLORS.brown }}>
+                {activeSearchTerm
+                  ? "No quests match your search"
+                  : view === "current"
+                    ? "No quests found"
+                    : "No upcoming quests found"}
+              </div>
+            )}
 
-                    {view === "upcoming" &&
-                      pagedUpcomingQuests.map((quest) => {
-                        const upcoming = upcomingQuests.find((item) => item.id === quest.id);
-                        return (
-                          <CompactQuestCard
-                            key={quest.id}
-                            quest={quest}
-                            questParticipantNames={getQuestParticipantNames(quest, homeUsers)}
-                            isUpcoming={true}
-                            onClick={() =>
-                              openQuestDetails(quest, "upcoming", upcoming?.next_spawn_at)
-                            }
-                          />
-                        );
-                      })}
-                  </motion.div>
-                </AnimatePresence>
-              ) : (
-                <div className="py-16 text-center font-serif" style={{ color: COLORS.brown }}>
-                  {activeSearchTerm
-                    ? "No quests match your search"
-                    : view === "current"
-                      ? "No quests found"
-                      : "No upcoming quests found"}
-                </div>
-              )}
+            {activePageCount > 1 && (
+              <div className="mt-4 flex items-center justify-between gap-3">
+                <button
+                  type="button"
+                  onClick={() => goToPage(activePage - 1)}
+                  disabled={activePage === 0}
+                  className="px-4 py-2 font-serif text-sm uppercase tracking-wide disabled:opacity-35"
+                  style={{
+                    border: `1px solid ${COLORS.gold}`,
+                    color: COLORS.gold,
+                    backgroundColor: "rgba(30, 21, 17, 0.65)",
+                  }}
+                >
+                  ← Prev
+                </button>
 
-              {activePageCount > 1 && (
-                <div className="mt-4 flex items-center justify-between gap-3">
-                  <button
-                    type="button"
-                    onClick={() => goToPage(activePage - 1)}
-                    disabled={activePage === 0}
-                    className="px-4 py-2 font-serif text-sm uppercase tracking-wide disabled:opacity-35"
-                    style={{
-                      border: `1px solid ${COLORS.gold}`,
-                      color: COLORS.gold,
-                      backgroundColor: "rgba(30, 21, 17, 0.65)",
-                    }}
-                  >
-                    ← Prev
-                  </button>
-
-                  <button
-                    type="button"
-                    onClick={() => goToPage(activePage + 1)}
-                    disabled={activePage >= activePageCount - 1}
-                    className="px-4 py-2 font-serif text-sm uppercase tracking-wide disabled:opacity-35"
-                    style={{
-                      border: `1px solid ${COLORS.gold}`,
-                      color: COLORS.gold,
-                      backgroundColor: "rgba(30, 21, 17, 0.65)",
-                    }}
-                  >
-                    Next →
-                  </button>
-                </div>
-              )}
-            </div>
+                <button
+                  type="button"
+                  onClick={() => goToPage(activePage + 1)}
+                  disabled={activePage >= activePageCount - 1}
+                  className="px-4 py-2 font-serif text-sm uppercase tracking-wide disabled:opacity-35"
+                  style={{
+                    border: `1px solid ${COLORS.gold}`,
+                    color: COLORS.gold,
+                    backgroundColor: "rgba(30, 21, 17, 0.65)",
+                  }}
+                >
+                  Next →
+                </button>
+              </div>
+            )}
           </div>
+        </div>
       )}
 
       {!loading && view === "current" && quests.length === 0 && !currentSearchTerm && (

--- a/frontend/src/pages/Board.tsx
+++ b/frontend/src/pages/Board.tsx
@@ -20,7 +20,7 @@ type QuestCollectionView = "current" | "upcoming";
 
 interface CompactQuestCardProps {
   quest: Quest;
-  questOwnerName?: string;
+  questParticipantNames?: string;
   isUpcoming?: boolean;
   isDailyBounty?: boolean;
   onClick: () => void;
@@ -28,7 +28,7 @@ interface CompactQuestCardProps {
 
 function CompactQuestCard({
   quest,
-  questOwnerName,
+  questParticipantNames,
   isUpcoming = false,
   isDailyBounty = false,
   onClick,
@@ -69,10 +69,10 @@ function CompactQuestCard({
         {quest.description || "No description"}
       </p>
 
-      {questOwnerName && (
+      {questParticipantNames && (
         <div className="mb-3 text-[11px] sm:text-xs font-serif uppercase tracking-wide">
-          <span style={{ color: COLORS.brown }}>For:</span>{" "}
-          <span style={{ color: COLORS.gold }}>{questOwnerName}</span>
+          <span style={{ color: COLORS.brown }}>Party:</span>{" "}
+          <span style={{ color: COLORS.gold }}>{questParticipantNames}</span>
         </div>
       )}
 
@@ -124,11 +124,31 @@ const toUpcomingQuest = (upcoming: UpcomingSubscription): Quest => ({
   due_date: null,
   corrupted_at: null,
   template: upcoming.template,
+  participants: [
+    {
+      id: upcoming.id,
+      quest_id: upcoming.id,
+      user_id: upcoming.user_id,
+      xp_awarded: null,
+      gold_awarded: null,
+      completed_at: null,
+      created_at: upcoming.created_at,
+    },
+  ],
 });
 
 const getPageCount = (items: unknown[]) => Math.max(1, Math.ceil(items.length / QUESTS_PER_PAGE));
 const getCurrentBoardQuests = (quests: Quest[]) => quests.filter((quest) => !quest.completed);
-const matchesQuestSearch = (quest: Quest, ownerName: string | undefined, searchTerm: string) => {
+const getQuestParticipantUserIds = (quest: Quest) =>
+  quest.participants && quest.participants.length > 0
+    ? quest.participants.map((participant) => participant.user_id)
+    : [quest.user_id];
+const getQuestParticipantNames = (quest: Quest, homeUsers: Record<number, string>) =>
+  getQuestParticipantUserIds(quest)
+    .map((participantUserId) => homeUsers[participantUserId])
+    .filter(Boolean)
+    .join(", ");
+const matchesQuestSearch = (quest: Quest, participantNames: string | undefined, searchTerm: string) => {
   const normalizedSearch = searchTerm.trim().toLowerCase();
   if (!normalizedSearch) return true;
 
@@ -137,7 +157,7 @@ const matchesQuestSearch = (quest: Quest, ownerName: string | undefined, searchT
     quest.title,
     quest.description,
     quest.tags,
-    ownerName,
+    participantNames,
   ];
 
   return searchableFields.some((value) =>
@@ -146,7 +166,7 @@ const matchesQuestSearch = (quest: Quest, ownerName: string | undefined, searchT
 };
 
 export default function Board() {
-  const { token } = useAuth();
+  const { token, userId } = useAuth();
   const { playSound } = useSound();
   const [view, setView] = useState<"current" | "upcoming">("current");
   const [quests, setQuests] = useState<Quest[]>([]);
@@ -375,18 +395,41 @@ export default function Board() {
     dailyBounty?.status === "assigned" && dailyBounty.quest && !dailyBounty.quest.completed
       ? dailyBounty.quest
       : null;
+  const splitIntegerReward = (total: number, participantCount: number): number[] => {
+    const baseShare = Math.floor(total / participantCount);
+    const remainder = total % participantCount;
+    return Array.from({ length: participantCount }, (_, index) =>
+      baseShare + (index < remainder ? 1 : 0)
+    );
+  };
+  const getQuestRewardShare = (quest: Quest, participantUserId: number, reward: "xp" | "gold") => {
+    const participantIds = getQuestParticipantUserIds(quest).sort((a, b) => a - b);
+    const participantIndex = participantIds.indexOf(participantUserId);
+    if (participantIndex === -1) return reward === "xp" ? quest.xp_reward : quest.gold_reward;
+
+    const rewardTotal = reward === "xp" ? quest.xp_reward : quest.gold_reward;
+    return splitIntegerReward(rewardTotal, participantIds.length)[participantIndex] ?? rewardTotal;
+  };
+  const activeBountyXpShare =
+    activeBountyQuest && userId !== null
+      ? getQuestRewardShare(activeBountyQuest, userId, "xp")
+      : activeBountyQuest?.xp_reward ?? 0;
+  const activeBountyGoldShare =
+    activeBountyQuest && userId !== null
+      ? getQuestRewardShare(activeBountyQuest, userId, "gold")
+      : activeBountyQuest?.gold_reward ?? 0;
   const fullUpcomingQuests = useMemo(() => upcomingQuests.map(toUpcomingQuest), [upcomingQuests]);
   const filteredCurrentQuests = useMemo(
     () =>
       quests.filter((quest) =>
-        matchesQuestSearch(quest, homeUsers[quest.user_id], currentSearchTerm)
+        matchesQuestSearch(quest, getQuestParticipantNames(quest, homeUsers), currentSearchTerm)
       ),
     [quests, homeUsers, currentSearchTerm]
   );
   const filteredUpcomingQuests = useMemo(
     () =>
       fullUpcomingQuests.filter((quest) =>
-        matchesQuestSearch(quest, homeUsers[quest.user_id], upcomingSearchTerm)
+        matchesQuestSearch(quest, getQuestParticipantNames(quest, homeUsers), upcomingSearchTerm)
       ),
     [fullUpcomingQuests, homeUsers, upcomingSearchTerm]
   );
@@ -643,10 +686,10 @@ export default function Board() {
             <div className="flex flex-wrap items-center justify-between gap-4">
               <div className="flex gap-6 text-sm font-serif" style={{ color: COLORS.gold }}>
                 <span>
-                  XP: {activeBountyQuest.xp_reward}
+                  Your XP: {activeBountyXpShare}
                 </span>
                 <span>
-                  Gold: {activeBountyQuest.gold_reward} x3 = {activeBountyQuest.gold_reward * 3}
+                  Your Gold: {activeBountyGoldShare} x3 = {activeBountyGoldShare * 3}
                 </span>
               </div>
               <span
@@ -747,7 +790,7 @@ export default function Board() {
                         <CompactQuestCard
                           key={quest.id}
                           quest={quest}
-                          questOwnerName={homeUsers[quest.user_id]}
+                          questParticipantNames={getQuestParticipantNames(quest, homeUsers)}
                           isDailyBounty={activeBountyQuest?.id === quest.id}
                           onClick={() => openQuestDetails(quest, "current")}
                         />
@@ -760,7 +803,7 @@ export default function Board() {
                           <CompactQuestCard
                             key={quest.id}
                             quest={quest}
-                            questOwnerName={homeUsers[quest.user_id]}
+                            questParticipantNames={getQuestParticipantNames(quest, homeUsers)}
                             isUpcoming={true}
                             onClick={() =>
                               openQuestDetails(quest, "upcoming", upcoming?.next_spawn_at)
@@ -932,7 +975,7 @@ export default function Board() {
             >
               <QuestCard
                 quest={selectedQuest}
-                questOwnerName={homeUsers[selectedQuest.user_id]}
+                questParticipantNames={getQuestParticipantNames(selectedQuest, homeUsers)}
                 questCreatorName={homeUsers[selectedQuest.created_by]}
                 onComplete={handleCompleteQuest}
                 onAbandon={selectedQuestView === "current" ? openAbandonConfirm : undefined}

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -69,6 +69,13 @@ export default function Profile() {
     [completedQuests]
   );
   const completedCount = completedQuests.length;
+  const getCurrentUserQuestAward = (quest: Quest) => {
+    const participantAward = quest.participants?.find((participant) => participant.user_id === userId);
+    return {
+      xp: participantAward?.xp_awarded ?? quest.xp_reward,
+      gold: participantAward?.gold_awarded ?? quest.gold_reward,
+    };
+  };
 
   const handleCopyInviteCode = async () => {
     if (!homeInfo) return;
@@ -480,32 +487,35 @@ export default function Profile() {
           <div className="space-y-3">
             {sortedCompletedQuests
               .slice(0, showAllQuests ? sortedCompletedQuests.length : 5)
-              .map((quest) => (
-                <button
-                  type="button"
-                  onClick={() => setSelectedCompletedQuest(quest)}
-                  key={quest.id}
-                  className="w-full p-4 rounded text-left transition-all hover:brightness-110"
-                  style={{
-                    backgroundColor: COLORS.dark,
-                    borderLeftColor: COLORS.greenSuccess,
-                    borderLeftWidth: "4px",
-                  }}
-                >
-                  <p className="font-serif font-bold mb-1" style={{ color: COLORS.parchment }}>
-                    {quest.display_name || quest.title}
-                  </p>
-                  <div className="flex justify-between items-center text-xs">
-                    <p style={{ color: COLORS.brown }}>
-                      Completed {new Date(quest.completed_at!).toLocaleDateString()}
+              .map((quest) => {
+                const award = getCurrentUserQuestAward(quest);
+                return (
+                  <button
+                    type="button"
+                    onClick={() => setSelectedCompletedQuest(quest)}
+                    key={quest.id}
+                    className="w-full p-4 rounded text-left transition-all hover:brightness-110"
+                    style={{
+                      backgroundColor: COLORS.dark,
+                      borderLeftColor: COLORS.greenSuccess,
+                      borderLeftWidth: "4px",
+                    }}
+                  >
+                    <p className="font-serif font-bold mb-1" style={{ color: COLORS.parchment }}>
+                      {quest.display_name || quest.title}
                     </p>
-                    <div className="flex gap-3 items-center">
-                      <span style={{ color: COLORS.gold }}>+{quest.xp_reward} XP</span>
-                      <span style={{ color: COLORS.gold }}>+{quest.gold_reward} Gold</span>
+                    <div className="flex justify-between items-center text-xs">
+                      <p style={{ color: COLORS.brown }}>
+                        Completed {new Date(quest.completed_at!).toLocaleDateString()}
+                      </p>
+                      <div className="flex gap-3 items-center">
+                        <span style={{ color: COLORS.gold }}>+{award.xp} XP</span>
+                        <span style={{ color: COLORS.gold }}>+{award.gold} Gold</span>
+                      </div>
                     </div>
-                  </div>
-                </button>
-              ))}
+                  </button>
+                );
+              })}
             {!showAllQuests && completedQuests.length > 5 && (
               <p className="text-center text-sm pt-2" style={{ color: COLORS.brown }}>
                 Showing 5 most recent of {completedCount} total completed quests

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -70,7 +70,9 @@ export default function Profile() {
   );
   const completedCount = completedQuests.length;
   const getCurrentUserQuestAward = (quest: Quest) => {
-    const participantAward = quest.participants?.find((participant) => participant.user_id === userId);
+    const participantAward = quest.participants?.find(
+      (participant) => participant.user_id === userId
+    );
     return {
       xp: participantAward?.xp_awarded ?? quest.xp_reward,
       gold: participantAward?.gold_awarded ?? quest.gold_reward,

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -44,6 +44,9 @@ const buildHeaders = (token?: string, contentType: boolean = false): HeadersInit
   return headers;
 };
 
+const withOptionalUserId = (path: string, userId?: number | null): string =>
+  userId === null || userId === undefined ? path : `${path}${path.includes("?") ? "&" : "?"}user_id=${userId}`;
+
 const extractErrorMessage = (error: unknown, fallback: string): string => {
   if (!error || typeof error !== "object") return fallback;
 
@@ -225,13 +228,14 @@ export const api = {
         tags?: string;
         xp_reward?: number;
         gold_reward?: number;
+        participant_user_ids?: number[];
       },
       token: string,
-      userId: number,
+      userId?: number | null,
       skipAI: boolean = false
     ): Promise<Quest> =>
       requestJSON<Quest>(
-        `/quests/ai-scribe?user_id=${userId}&skip_ai=${skipAI}`,
+        withOptionalUserId(`/quests/ai-scribe?skip_ai=${skipAI}`, userId),
         {
           method: "POST",
           headers: buildHeaders(token, true),
@@ -240,15 +244,26 @@ export const api = {
         "Failed to create AI Scribe quest"
       ),
 
-    createRandom: async (token: string, userId: number): Promise<Quest> =>
-      requestJSON<Quest>(
-        `/quests/random?user_id=${userId}`,
+    createRandom: async (
+      token: string,
+      userId?: number | null,
+      participantUserIds?: number[]
+    ): Promise<Quest> => {
+      const params = new URLSearchParams();
+      if (userId !== null && userId !== undefined) params.set("user_id", String(userId));
+      participantUserIds?.forEach((participantUserId) =>
+        params.append("participant_user_ids", String(participantUserId))
+      );
+      const query = params.toString();
+      return requestJSON<Quest>(
+        `/quests/random${query ? `?${query}` : ""}`,
         {
           method: "POST",
           headers: buildHeaders(token),
         },
         "Failed to create random quest"
-      ),
+      );
+    },
 
     convertToTemplate: async (
       questId: number,
@@ -282,6 +297,7 @@ export const api = {
         gold_reward?: number;
         due_in_hours?: number | null;
         user_id?: number;
+        participant_user_ids?: number[];
       },
       token: string
     ): Promise<Quest> =>
@@ -328,9 +344,9 @@ export const api = {
         "Failed to create quest template"
       ),
 
-    create: async (questData: QuestCreateRequest, token: string, userId: number): Promise<Quest> =>
+    create: async (questData: QuestCreateRequest, token: string, userId?: number | null): Promise<Quest> =>
       requestJSON<Quest>(
-        `/quests?user_id=${userId}`,
+        withOptionalUserId("/quests", userId),
         {
           method: "POST",
           headers: buildHeaders(token, true),

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -45,7 +45,9 @@ const buildHeaders = (token?: string, contentType: boolean = false): HeadersInit
 };
 
 const withOptionalUserId = (path: string, userId?: number | null): string =>
-  userId === null || userId === undefined ? path : `${path}${path.includes("?") ? "&" : "?"}user_id=${userId}`;
+  userId === null || userId === undefined
+    ? path
+    : `${path}${path.includes("?") ? "&" : "?"}user_id=${userId}`;
 
 const extractErrorMessage = (error: unknown, fallback: string): string => {
   if (!error || typeof error !== "object") return fallback;
@@ -168,11 +170,7 @@ export const api = {
     getAll: async (token: string): Promise<Quest[]> =>
       requestJSON<Quest[]>("/quests", { headers: buildHeaders(token) }, "Failed to fetch quests"),
 
-    getByUser: async (
-      userId: number,
-      token: string,
-      completed?: boolean
-    ): Promise<Quest[]> => {
+    getByUser: async (userId: number, token: string, completed?: boolean): Promise<Quest[]> => {
       const params = new URLSearchParams();
       if (completed !== undefined) {
         params.set("completed", completed ? "true" : "false");
@@ -344,7 +342,11 @@ export const api = {
         "Failed to create quest template"
       ),
 
-    create: async (questData: QuestCreateRequest, token: string, userId?: number | null): Promise<Quest> =>
+    create: async (
+      questData: QuestCreateRequest,
+      token: string,
+      userId?: number | null
+    ): Promise<Quest> =>
       requestJSON<Quest>(
         withOptionalUserId("/quests", userId),
         {

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -34,7 +34,7 @@ export interface Quest {
   display_name: string | null;
   description: string | null;
   tags: string | null;
-  xp_reward: number; // Base at creation, actual earned after completion
+  xp_reward: number; // Base total quest reward; participant shares are in participants
   gold_reward: number;
   recurrence: string; // Snapshot of recurrence when quest was created
   schedule: string | null; // Snapshot of schedule when quest was created
@@ -44,6 +44,17 @@ export interface Quest {
   due_date: string | null; // DEPRECATED: use due_in_hours instead
   corrupted_at: string | null;
   template: QuestTemplate | null; // Null for standalone quests
+  participants: QuestParticipant[];
+}
+
+export interface QuestParticipant {
+  id: number;
+  quest_id: number;
+  user_id: number;
+  xp_awarded: number | null;
+  gold_awarded: number | null;
+  completed_at: string | null;
+  created_at: string;
 }
 
 export interface User {
@@ -76,12 +87,34 @@ export interface QuestCompleteResponse {
   rewards: {
     xp: number;
     gold: number;
+    base_xp?: number;
+    base_gold?: number;
     is_daily_bounty: boolean;
     is_corrupted: boolean;
+    corruption_debuff?: number;
     bounty_multiplier: number;
     bounty_gold_multiplier?: number;
     bounty_xp_multiplier?: number;
+    xp_boost_active?: boolean;
+    xp_boost_remaining?: number;
+    participants?: QuestParticipantReward[];
   };
+}
+
+export interface QuestParticipantReward {
+  user_id: number;
+  xp: number;
+  gold: number;
+  base_xp: number;
+  base_gold: number;
+  is_daily_bounty: boolean;
+  is_corrupted: boolean;
+  corruption_debuff: number;
+  bounty_multiplier: number;
+  bounty_gold_multiplier: number;
+  bounty_xp_multiplier: number;
+  xp_boost_active: boolean;
+  xp_boost_remaining: number;
 }
 
 export interface BountyCheckResponse {
@@ -118,6 +151,7 @@ export interface QuestTemplateUpdateRequest {
 export interface QuestCreateRequest {
   quest_template_id: number;
   due_date?: string | null;
+  participant_user_ids?: number[];
 }
 
 export interface Achievement {


### PR DESCRIPTION
## Summary

Adds multi-participant quest support while keeping the legacy `quest.user_id` field aligned to the primary participant for compatibility.

- Adds a `quest_participant` join table with runtime backfill from existing quest rows.
- Allows quest creation/edit flows to send `participant_user_ids` for shared quest participants.
- Splits base XP and gold across participants on completion, then applies per-user effects like daily bounty, corruption/shield, and XP boost.
- Updates user quest lists, daily bounty eligibility, achievements, deletion cleanup, recurring generation, and trigger-created quests to respect participant rows.
- Updates board/profile UI and docs to show single-user quests as "For" and multi-user quests as "Party".
- Moves template-created quest participant selection into the template defaults modal as "New Quest For/Party", so it is tied to the new instance created by "Save Defaults & Create Quest" rather than the template browser.

## Follow-up Notes Addressed

- Clarified why participant ID dedupe exists: direct API clients can send duplicate IDs, and dedupe prevents unique-constraint failures and duplicate reward shares.
- Clarified `quest.user_id`: it is the first selected primary participant retained for legacy compatibility, not the source of truth for assignment.
- Clarified runtime compatibility/backfill code should stay through production rollout and be removed only in a later cleanup after deployed DBs are backfilled.
- Clarified template UX by removing the participant selector from the template browser and showing "New Quest For/Party" in the template defaults modal.

## Validation

- `git diff --check`
- `bun run typecheck`
- `bun test scripts/editQuestModalHelpers.test.ts`

## Notes

Local backend pytest currently hangs while entering `TestClient` lifespan setup before the first test body runs, so backend verification should rely on GitHub Actions for this PR. A focused participant test run passed earlier in this branch before the final comment-addressing follow-ups.