### PR TITLE
[codex] Show corrupted quest reward previews

### DIFF
--- a/backend/app/models/quest.py
+++ b/backend/app/models/quest.py
@@ -220,6 +220,13 @@ class QuestRead(SQLModel):
     due_in_hours: Optional[int]
     due_date: Optional[datetime]
     corrupted_at: Optional[datetime]
+    # Reward preview for incomplete quests, after the authenticated user's active
+    # household corruption debuff and before bounty or XP boost modifiers.
+    effective_xp_reward: Optional[int] = None
+    effective_gold_reward: Optional[int] = None
+    corruption_debuff: Optional[float] = None
+    corrupted_quest_count: int = 0
+    corruption_debuff_active: bool = False
     # Include template data for convenience (may be null for standalone quests)
     template: Optional[QuestTemplateRead]
     participants: list[QuestParticipantRead] = Field(default_factory=list)

--- a/backend/app/routes/quest.py
+++ b/backend/app/routes/quest.py
@@ -29,35 +29,90 @@ from app.services.scribe import ScribeResponse, generate_quest_content
 
 router = APIRouter(prefix="/api/quests", tags=["quests"])
 
+CORRUPTION_DEBUFF_PERCENT = 20
+
+
+def _as_aware_datetime(value: datetime) -> datetime:
+    """Treat legacy naive datetimes as UTC so reward previews match completion."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value
+
+
+def _has_active_shield(user: User) -> bool:
+    if not user.active_shield_expiry:
+        return False
+
+    return _as_aware_datetime(user.active_shield_expiry) > datetime.now(timezone.utc)
+
+
+def _get_corrupted_quest_count(db: Session, home_id: int) -> int:
+    corrupted_quests = db.exec(
+        select(Quest.id).where(
+            (Quest.home_id == home_id)
+            & (Quest.quest_type == "corrupted")
+            & (Quest.completed == False)  # noqa: E712
+        )
+    ).all()
+    return len(corrupted_quests)
+
+
+def _corruption_multiplier(corrupted_quest_count: int) -> float:
+    if corrupted_quest_count <= 0:
+        return 1.0
+
+    return 1.0 - (CORRUPTION_DEBUFF_PERCENT / 100.0)
+
 
 def _calculate_corruption_debuff(db: Session, home_id: int, user: User) -> float:
     """
     Calculate house-wide corruption debuff multiplier.
 
-    Returns multiplier to apply to rewards (1.0 = no debuff, 0.85 = -15% debuff, etc.)
+    Returns multiplier to apply to rewards (1.0 = no debuff, 0.8 = -20% debuff, etc.)
 
     Debuff calculation:
-    - Each corrupted quest in the home adds -5% penalty
-    - Stacks up to -50% cap (10 corrupted quests)
+    - Any active corrupted quest in the home applies a flat -20% penalty
+    - Additional corrupted quests do not increase the penalty
     - Shield suppresses debuff temporarily (returns 1.0 if active)
     """
-    # Check if user has active shield
-    now = datetime.now(timezone.utc)
-    if user.active_shield_expiry and user.active_shield_expiry > now:
+    if _has_active_shield(user):
         return 1.0  # No debuff - shield protects
 
-    # Count corrupted quests in the home
-    corrupted_count = db.exec(
-        select(Quest).where((Quest.home_id == home_id) & (Quest.quest_type == "corrupted") & (Quest.completed == False))  # noqa: E712
-    ).all()
+    return _corruption_multiplier(_get_corrupted_quest_count(db, home_id))
 
-    corrupted_count = len(corrupted_count)
 
-    # Calculate debuff: -5% per corrupted quest, cap at -50%
-    debuff_percent = min(corrupted_count * 5, 50)
-    multiplier = 1.0 - (debuff_percent / 100.0)
+def _get_quest_reward_preview_context(db: Session, auth: dict) -> tuple[int, float]:
+    user = crud_user.get_user(db, auth["user_id"])
+    if not user or user.home_id != auth["home_id"]:
+        raise HTTPException(
+            status_code=404,
+            detail=create_error_detail(ErrorCode.USER_NOT_FOUND, details={"user_id": auth["user_id"]}),
+        )
 
-    return multiplier
+    corrupted_quest_count = _get_corrupted_quest_count(db, auth["home_id"])
+    if _has_active_shield(user):
+        return corrupted_quest_count, 1.0
+
+    return corrupted_quest_count, _corruption_multiplier(corrupted_quest_count)
+
+
+def _quest_to_read(quest: Quest, corrupted_quest_count: int, corruption_debuff: float) -> QuestRead:
+    quest_read = QuestRead.model_validate(quest)
+
+    if quest.completed:
+        return quest_read
+
+    quest_read.corrupted_quest_count = corrupted_quest_count
+    quest_read.corruption_debuff = corruption_debuff
+    quest_read.corruption_debuff_active = corrupted_quest_count > 0 and corruption_debuff < 1.0
+    quest_read.effective_xp_reward = int(quest.xp_reward * corruption_debuff)
+    quest_read.effective_gold_reward = int(quest.gold_reward * corruption_debuff)
+    return quest_read
+
+
+def _quests_to_read(quests: list[Quest], db: Session, auth: dict) -> list[QuestRead]:
+    corrupted_quest_count, corruption_debuff = _get_quest_reward_preview_context(db, auth)
+    return [_quest_to_read(quest, corrupted_quest_count, corruption_debuff) for quest in quests]
 
 
 def _dedupe_user_ids(user_ids: list[int]) -> list[int]:
@@ -131,12 +186,15 @@ def get_all_quests(db: Session = Depends(get_db), auth: dict = Depends(get_curre
     # Check and corrupt any overdue quests before returning the list
     crud_quest.check_and_corrupt_overdue_quests(db)
 
-    return crud_quest.get_quests_by_home(db, auth["home_id"])
+    quests = crud_quest.get_quests_by_home(db, auth["home_id"])
+    return _quests_to_read(quests, db, auth)
 
 
 @router.get("/{quest_id}", response_model=QuestRead)
 def get_quest(quest_id: int, db: Session = Depends(get_db), auth: dict = Depends(get_current_user)):
     """Get quest by ID (only those in your home can access)"""
+    crud_quest.check_and_corrupt_overdue_quests(db)
+
     quest = crud_quest.get_quest(db, quest_id)
     if not quest or quest.home_id != auth["home_id"]:
         raise HTTPException(
@@ -144,7 +202,8 @@ def get_quest(quest_id: int, db: Session = Depends(get_db), auth: dict = Depends
             detail=create_error_detail(ErrorCode.QUEST_NOT_FOUND, details={"quest_id": quest_id}),
         )
 
-    return quest
+    corrupted_quest_count, corruption_debuff = _get_quest_reward_preview_context(db, auth)
+    return _quest_to_read(quest, corrupted_quest_count, corruption_debuff)
 
 
 @router.get("/user/{user_id}", response_model=list[QuestRead])
@@ -163,7 +222,9 @@ def get_user_quests(
             detail=create_error_detail(ErrorCode.USER_NOT_FOUND, details={"user_id": user_id}),
         )
 
-    return crud_quest.get_quests_by_user(db, auth["home_id"], user_id, completed)
+    crud_quest.check_and_corrupt_overdue_quests(db)
+    quests = crud_quest.get_quests_by_user(db, auth["home_id"], user_id, completed)
+    return _quests_to_read(quests, db, auth)
 
 
 @router.get("/templates/{template_id}", response_model=QuestTemplateRead)
@@ -391,7 +452,7 @@ def complete_quest(quest_id: int, db: Session = Depends(get_db), auth: dict = De
 
     **Reward Calculation Order**:
     1. Base rewards from template
-    2. Apply corruption debuff (-5% per corrupted quest in home, capped at -50%)
+    2. Apply corruption debuff (-20% while any corrupted quest exists in home)
     3. Apply bounty bonus (3x gold only if daily bounty; XP unchanged)
     4. Apply XP boost (2x if Heroic Elixir active)
 

--- a/backend/tests/test_quest_corruption.py
+++ b/backend/tests/test_quest_corruption.py
@@ -7,6 +7,7 @@ from fastapi.testclient import TestClient
 from sqlmodel import Session, select
 
 from app.models.quest import Quest
+from app.models.user import User
 
 
 @pytest.fixture
@@ -206,12 +207,11 @@ def test_corrupted_quest_gives_bonus_rewards(client: TestClient, home_with_user_
 
     # Verify corruption triggers debuff (not bonus)
     assert result["rewards"]["is_corrupted"] is True
-    assert result["rewards"]["corruption_debuff"] == 0.95  # -5% debuff (1 corrupted quest)
+    assert result["rewards"]["corruption_debuff"] == 0.8  # -20% flat debuff while corruption is active
     assert result["rewards"]["base_xp"] == 50
     assert result["rewards"]["base_gold"] == 25
-    # After debuff: 50 * 0.95 = 47 XP, 25 * 0.95 = 23 gold (floored to int)
-    assert result["rewards"]["xp"] == 47
-    assert result["rewards"]["gold"] == 23
+    assert result["rewards"]["xp"] == 40
+    assert result["rewards"]["gold"] == 20
 
 
 def test_future_due_date_not_corrupted(client: TestClient, home_with_user_and_template):
@@ -312,6 +312,117 @@ def test_corrupted_quest_type_in_response(client: TestClient, home_with_user_and
     assert single_quest["quest_type"] == "corrupted"
 
 
+def test_corruption_reward_preview_updates_available_quests(
+    client: TestClient, home_with_user_and_template, db: Session
+):
+    """Quest reads show reduced reward previews while household corruption is active."""
+    _home_id, user_id, template_id = home_with_user_and_template
+
+    corrupted_response = client.post(
+        f"/api/quests?user_id={user_id}",
+        json={"quest_template_id": template_id},
+    )
+    standard_response = client.post(
+        f"/api/quests?user_id={user_id}",
+        json={"quest_template_id": template_id},
+    )
+    corrupted_quest_id = corrupted_response.json()["id"]
+    standard_quest_id = standard_response.json()["id"]
+
+    quest = db.exec(select(Quest).where(Quest.id == corrupted_quest_id)).first()
+    quest.created_at = datetime.now(timezone.utc) - timedelta(hours=26)
+    db.add(quest)
+    db.commit()
+
+    client.post("/api/quests/check-corruption")
+
+    all_quests = client.get("/api/quests").json()
+    quest_by_id = {quest_data["id"]: quest_data for quest_data in all_quests}
+    corrupted_quest = quest_by_id[corrupted_quest_id]
+    standard_quest = quest_by_id[standard_quest_id]
+
+    assert corrupted_quest["quest_type"] == "corrupted"
+    assert standard_quest["quest_type"] == "standard"
+    for quest_data in (corrupted_quest, standard_quest):
+        assert quest_data["corrupted_quest_count"] == 1
+        assert quest_data["corruption_debuff"] == 0.8
+        assert quest_data["corruption_debuff_active"] is True
+        assert quest_data["effective_xp_reward"] == 40
+        assert quest_data["effective_gold_reward"] == 20
+
+    single_quest = client.get(f"/api/quests/{standard_quest_id}").json()
+    assert single_quest["effective_xp_reward"] == 40
+    assert single_quest["effective_gold_reward"] == 20
+
+    user_quests = client.get(f"/api/quests/user/{user_id}").json()
+    user_standard_quest = next(
+        quest_data for quest_data in user_quests if quest_data["id"] == standard_quest_id
+    )
+    assert user_standard_quest["effective_xp_reward"] == 40
+    assert user_standard_quest["effective_gold_reward"] == 20
+
+
+def test_corruption_reward_preview_stays_flat_with_multiple_corrupted_quests(
+    client: TestClient, home_with_user_and_template, db: Session
+):
+    """Multiple corrupted quests still apply the same flat household debuff."""
+    _home_id, user_id, template_id = home_with_user_and_template
+
+    quest_ids = []
+    for _i in range(3):
+        quest_response = client.post(
+            f"/api/quests?user_id={user_id}",
+            json={"quest_template_id": template_id},
+        )
+        quest_ids.append(quest_response.json()["id"])
+
+    for quest_id in quest_ids:
+        quest = db.exec(select(Quest).where(Quest.id == quest_id)).first()
+        quest.created_at = datetime.now(timezone.utc) - timedelta(hours=26)
+        db.add(quest)
+    db.commit()
+
+    client.post("/api/quests/check-corruption")
+
+    all_quests = client.get("/api/quests").json()
+    for quest_data in all_quests:
+        assert quest_data["corrupted_quest_count"] == 3
+        assert quest_data["corruption_debuff"] == 0.8
+        assert quest_data["effective_xp_reward"] == 40
+        assert quest_data["effective_gold_reward"] == 20
+
+
+def test_corruption_reward_preview_respects_active_shield(
+    client: TestClient, home_with_user_and_template, db: Session
+):
+    """A user's active shield suppresses the previewed corruption debuff."""
+    _home_id, user_id, template_id = home_with_user_and_template
+
+    quest_response = client.post(
+        f"/api/quests?user_id={user_id}",
+        json={"quest_template_id": template_id},
+    )
+    quest_id = quest_response.json()["id"]
+
+    quest = db.exec(select(Quest).where(Quest.id == quest_id)).first()
+    quest.created_at = datetime.now(timezone.utc) - timedelta(hours=26)
+    db.add(quest)
+
+    user = db.exec(select(User).where(User.id == user_id)).first()
+    user.active_shield_expiry = datetime.now(timezone.utc) + timedelta(hours=1)
+    db.add(user)
+    db.commit()
+
+    client.post("/api/quests/check-corruption")
+
+    quest_data = client.get(f"/api/quests/{quest_id}").json()
+    assert quest_data["corrupted_quest_count"] == 1
+    assert quest_data["corruption_debuff"] == 1.0
+    assert quest_data["corruption_debuff_active"] is False
+    assert quest_data["effective_xp_reward"] == 50
+    assert quest_data["effective_gold_reward"] == 25
+
+
 def test_corruption_timestamp_set_correctly(client: TestClient, home_with_user_and_template, db: Session):
     """Test that corrupted_at timestamp is set when quest becomes corrupted"""
     home_id, user_id, template_id = home_with_user_and_template
@@ -394,8 +505,8 @@ def test_daily_bounty_and_corruption_combined(client: TestClient, home_with_user
     assert result["rewards"]["is_corrupted"] is True
 
     # Check that both debuff and bounty multipliers are applied
-    # Debuff: -5% (0.95) for 1 corrupted quest, Bounty: XP x1 and Gold x3
-    assert result["rewards"]["corruption_debuff"] == 0.95
+    # Debuff: -20% while corruption is active, Bounty: XP x1 and Gold x3
+    assert result["rewards"]["corruption_debuff"] == 0.8
     assert result["rewards"]["bounty_multiplier"] == 3
     assert result["rewards"]["bounty_xp_multiplier"] == 1
     assert result["rewards"]["bounty_gold_multiplier"] == 3

--- a/docs/current-architecture.md
+++ b/docs/current-architecture.md
@@ -1,6 +1,6 @@
 # Current Architecture
 
-Last verified: 2026-04-16
+Last verified: 2026-04-20
 
 ## Source of truth priority
 
@@ -32,6 +32,12 @@ Last verified: 2026-04-16
   participant selected at creation/update time, not the only assignee.
 - Multi-user participation is stored in `quest_participant` with one row per quest/user.
 - `quest.xp_reward` and `quest.gold_reward` are the base rewards awarded to each participant.
+- Quest read responses include reward preview fields for incomplete quests:
+  `effective_xp_reward`, `effective_gold_reward`, `corruption_debuff`,
+  `corrupted_quest_count`, and `corruption_debuff_active`.
+- Corruption is a household-wide flat `-20%` reward preview/completion debuff whenever
+  at least one active quest in the household is corrupted. Additional corrupted quests do
+  not increase the percentage. A user's active shield suppresses the debuff for that user.
 - On completion, every participant starts from the full base XP/gold reward.
 - Per-user effects are applied to each participant's reward: daily bounty, corruption/shield, and XP boost.
 - Actual awarded XP/gold are stored on `quest_participant.xp_awarded` and `quest_participant.gold_awarded`.

--- a/frontend/src/components/QuestCard.tsx
+++ b/frontend/src/components/QuestCard.tsx
@@ -62,6 +62,16 @@ export default function QuestCard({
 }: QuestCardProps) {
   const typeStyles = getQuestTypeStyles(quest.quest_type);
   const isCorrupted = quest.quest_type === "corrupted";
+  const hasCorruptionDebuff =
+    !quest.completed && quest.corruption_debuff_active && (quest.corruption_debuff ?? 1) < 1;
+  const corruptionPenaltyPercent = hasCorruptionDebuff
+    ? Math.round((1 - (quest.corruption_debuff ?? 1)) * 100)
+    : 0;
+  const cardBorderColor = isCorrupted
+    ? typeStyles.borderColor
+    : isDailyBounty
+      ? "#6b5fb7"
+      : typeStyles.borderColor;
   const displayTitle = quest.display_name?.trim() || quest.title || "Unknown Quest";
   const originalTitle = quest.title?.trim() || "";
   const hasOriginalTitle = Boolean(
@@ -82,20 +92,24 @@ export default function QuestCard({
           0
         )
       : quest.gold_reward || 0;
-  const displayXpReward = quest.completed ? completedXpTotal : quest.xp_reward || 0;
+  const baseXpReward = quest.xp_reward || 0;
+  const baseGoldReward = quest.gold_reward || 0;
+  const previewXpReward = quest.effective_xp_reward ?? baseXpReward;
+  const previewGoldReward = quest.effective_gold_reward ?? baseGoldReward;
+  const displayXpReward = quest.completed ? completedXpTotal : previewXpReward;
   const displayGoldReward =
     isDailyBounty && !quest.completed && participantCount === 1
-      ? (quest.gold_reward || 0) * 3
+      ? previewGoldReward * 3
       : quest.completed
         ? completedGoldTotal
-        : quest.gold_reward || 0;
+        : previewGoldReward;
   const activePartyRewardLabel =
-    participantCount > 1 ? `Each participant gets ${quest.xp_reward || 0} XP` : null;
+    participantCount > 1 ? `Each participant gets ${previewXpReward} XP` : null;
   const activePartyGoldLabel =
     participantCount > 1
       ? isDailyBounty
-        ? "Each participant gets full gold; bounty multiplies yours"
-        : `Each participant gets ${quest.gold_reward || 0} gold`
+        ? `Each participant gets ${previewGoldReward} gold; bounty multiplies yours`
+        : `Each participant gets ${previewGoldReward} gold`
       : null;
 
   useEffect(() => {
@@ -156,7 +170,7 @@ export default function QuestCard({
       className="relative p-6 md:p-8 mb-6 md:mb-8 shadow-lg"
       style={{
         backgroundColor: COLORS.darkPanel,
-        borderColor: isDailyBounty ? "#6b5fb7" : typeStyles.borderColor,
+        borderColor: cardBorderColor,
         borderWidth: "3px",
         opacity: isUpcoming ? 0.6 : 1,
       }}
@@ -197,6 +211,18 @@ export default function QuestCard({
             }}
           >
             3x Gold Bounty
+          </span>
+        )}
+        {hasCorruptionDebuff && (
+          <span
+            className="px-2 py-1 rounded text-xs uppercase font-serif font-bold"
+            style={{
+              backgroundColor: "rgba(139, 58, 58, 0.24)",
+              color: "#ff8080",
+              border: "1px solid #ff8080",
+            }}
+          >
+            Household -{corruptionPenaltyPercent}%
           </span>
         )}
         {quest.due_in_hours && !quest.completed && (
@@ -330,6 +356,11 @@ export default function QuestCard({
           <div className="text-2xl md:text-3xl font-serif font-bold" style={{ color: COLORS.gold }}>
             {displayXpReward}
           </div>
+          {hasCorruptionDebuff && (
+            <div className="mt-1 text-xs font-serif" style={{ color: "#ff8080" }}>
+              Base {baseXpReward} XP, corruption -{corruptionPenaltyPercent}%
+            </div>
+          )}
           {participantCount > 1 && (
             <div className="mt-1 text-xs font-serif" style={{ color: COLORS.brown }}>
               {quest.completed ? "Total awarded to party" : activePartyRewardLabel}
@@ -351,6 +382,11 @@ export default function QuestCard({
               </span>
             )}
           </div>
+          {hasCorruptionDebuff && (
+            <div className="mt-1 text-xs font-serif" style={{ color: "#ff8080" }}>
+              Base {baseGoldReward} Gold, corruption -{corruptionPenaltyPercent}%
+            </div>
+          )}
           {participantCount > 1 && (
             <div className="mt-1 text-xs font-serif" style={{ color: COLORS.brown }}>
               {quest.completed ? "Total awarded to party" : activePartyGoldLabel}

--- a/frontend/src/pages/Board.tsx
+++ b/frontend/src/pages/Board.tsx
@@ -34,6 +34,21 @@ function CompactQuestCard({
   onClick,
 }: CompactQuestCardProps) {
   const participantLabel = (quest.participants?.length || 1) > 1 ? "Party" : "For";
+  const isCorrupted = quest.quest_type === "corrupted";
+  const hasCorruptionDebuff =
+    !quest.completed && quest.corruption_debuff_active && (quest.corruption_debuff ?? 1) < 1;
+  const corruptionPenaltyPercent = hasCorruptionDebuff
+    ? Math.round((1 - (quest.corruption_debuff ?? 1)) * 100)
+    : 0;
+  const baseXpReward = quest.xp_reward || 0;
+  const baseGoldReward = quest.gold_reward || 0;
+  const previewXpReward = quest.effective_xp_reward ?? baseXpReward;
+  const previewGoldReward = quest.effective_gold_reward ?? baseGoldReward;
+  const displayGoldReward =
+    isDailyBounty && !quest.completed ? previewGoldReward * 3 : previewGoldReward;
+  const borderColor = isCorrupted ? "#8b3a3a" : isDailyBounty ? "#6b5fb7" : COLORS.gold;
+  const titleColor = isCorrupted ? "#ff6b6b" : isDailyBounty ? "#c0b4ff" : COLORS.gold;
+  const rewardColor = hasCorruptionDebuff ? "#ff8080" : COLORS.gold;
 
   return (
     <button
@@ -42,7 +57,7 @@ function CompactQuestCard({
       className="w-full text-left p-3 sm:p-4 rounded-sm transition-all duration-200 hover:scale-[1.01] active:scale-[0.99]"
       style={{
         backgroundColor: "rgba(30, 21, 17, 0.7)",
-        border: `2px solid ${isDailyBounty ? "#6b5fb7" : COLORS.gold}`,
+        border: `2px solid ${borderColor}`,
         boxShadow: "0 6px 12px rgba(0, 0, 0, 0.25)",
         opacity: isUpcoming ? 0.8 : 1,
       }}
@@ -50,18 +65,36 @@ function CompactQuestCard({
       <div className="flex items-start justify-between gap-2 mb-2">
         <h3
           className="text-sm sm:text-base font-serif font-bold leading-tight line-clamp-2"
-          style={{ color: isDailyBounty ? "#c0b4ff" : COLORS.gold }}
+          style={{ color: titleColor }}
         >
           {quest.display_name || quest.title || "Unknown Quest"}
         </h3>
-        {quest.completed && (
-          <span
-            className="text-[10px] sm:text-xs px-2 py-0.5 font-serif uppercase"
-            style={{ backgroundColor: "rgba(95, 183, 84, 0.2)", color: COLORS.greenSuccess }}
-          >
-            Done
-          </span>
-        )}
+        <div className="flex shrink-0 flex-wrap justify-end gap-1">
+          {isCorrupted && (
+            <span
+              className="text-[10px] sm:text-xs px-2 py-0.5 font-serif uppercase"
+              style={{ backgroundColor: "rgba(139, 58, 58, 0.28)", color: "#ff8080" }}
+            >
+              Corrupted
+            </span>
+          )}
+          {isDailyBounty && (
+            <span
+              className="text-[10px] sm:text-xs px-2 py-0.5 font-serif uppercase"
+              style={{ backgroundColor: "rgba(107, 95, 183, 0.3)", color: "#c0b4ff" }}
+            >
+              3x
+            </span>
+          )}
+          {quest.completed && (
+            <span
+              className="text-[10px] sm:text-xs px-2 py-0.5 font-serif uppercase"
+              style={{ backgroundColor: "rgba(95, 183, 84, 0.2)", color: COLORS.greenSuccess }}
+            >
+              Done
+            </span>
+          )}
+        </div>
       </div>
 
       <p
@@ -79,7 +112,7 @@ function CompactQuestCard({
       )}
 
       <div
-        className="flex items-center justify-between text-xs font-serif"
+        className="flex items-center justify-between gap-3 text-xs font-serif"
         style={{ color: COLORS.brown }}
       >
         <div className="flex gap-2">
@@ -98,7 +131,14 @@ function CompactQuestCard({
               </span>
             ))}
         </div>
-        <span style={{ color: COLORS.gold }}>+{quest.xp_reward || 0} XP</span>
+        <span className="min-w-0 text-right" style={{ color: rewardColor }}>
+          +{previewXpReward} XP / +{displayGoldReward} Gold
+          {hasCorruptionDebuff && (
+            <span className="ml-1" style={{ color: "#ff8080" }}>
+              -{corruptionPenaltyPercent}%
+            </span>
+          )}
+        </span>
       </div>
     </button>
   );
@@ -125,6 +165,11 @@ const toUpcomingQuest = (upcoming: UpcomingSubscription): Quest => ({
   due_in_hours: upcoming.due_in_hours,
   due_date: null,
   corrupted_at: null,
+  effective_xp_reward: upcoming.template.xp_reward,
+  effective_gold_reward: upcoming.template.gold_reward,
+  corruption_debuff: null,
+  corrupted_quest_count: 0,
+  corruption_debuff_active: false,
   template: upcoming.template,
   participants: [
     {
@@ -397,12 +442,18 @@ export default function Board() {
     }
   };
 
+  const currentQuestById = useMemo(
+    () => new Map(quests.map((quest) => [quest.id, quest])),
+    [quests]
+  );
   const activeBountyQuest =
     dailyBounty?.status === "assigned" && dailyBounty.quest && !dailyBounty.quest.completed
-      ? dailyBounty.quest
+      ? (currentQuestById.get(dailyBounty.quest.id) ?? dailyBounty.quest)
       : null;
-  const activeBountyXpReward = activeBountyQuest?.xp_reward ?? 0;
-  const activeBountyGoldReward = activeBountyQuest?.gold_reward ?? 0;
+  const activeBountyXpReward =
+    activeBountyQuest?.effective_xp_reward ?? activeBountyQuest?.xp_reward ?? 0;
+  const activeBountyGoldReward =
+    activeBountyQuest?.effective_gold_reward ?? activeBountyQuest?.gold_reward ?? 0;
   const fullUpcomingQuests = useMemo(() => upcomingQuests.map(toUpcomingQuest), [upcomingQuests]);
   const filteredCurrentQuests = useMemo(
     () =>
@@ -429,6 +480,15 @@ export default function Board() {
     view === "current"
       ? quests.length > 0 || currentSearchTerm.trim().length > 0
       : upcomingQuests.length > 0 || upcomingSearchTerm.trim().length > 0;
+  const activeCorruptionDebuffQuest = quests.find(
+    (quest) => quest.corruption_debuff_active && (quest.corruption_debuff ?? 1) < 1
+  );
+  const activeCorruptionPenaltyPercent = activeCorruptionDebuffQuest
+    ? Math.round((1 - (activeCorruptionDebuffQuest.corruption_debuff ?? 1)) * 100)
+    : 0;
+  const activeCorruptedQuestCount =
+    activeCorruptionDebuffQuest?.corrupted_quest_count ??
+    quests.filter((quest) => quest.quest_type === "corrupted").length;
 
   const selectedQuestSequence = useMemo(() => {
     if (selectedQuestView === "current") return filteredCurrentQuests;
@@ -638,6 +698,24 @@ export default function Board() {
       {loading && (
         <div className="text-center py-12 md:py-16 font-serif" style={{ color: COLORS.brown }}>
           Loading quests...
+        </div>
+      )}
+
+      {view === "current" && activeCorruptionPenaltyPercent > 0 && (
+        <div
+          className="mb-6 flex flex-col gap-1 rounded-sm px-4 py-3 font-serif sm:flex-row sm:items-center sm:justify-between"
+          style={{
+            backgroundColor: "rgba(139, 58, 58, 0.18)",
+            border: "1px solid #8b3a3a",
+            color: "#ff8080",
+          }}
+        >
+          <span className="font-bold uppercase tracking-wide">Household Corruption</span>
+          <span className="text-sm">
+            {activeCorruptedQuestCount} corrupted{" "}
+            {activeCorruptedQuestCount === 1 ? "quest" : "quests"} • -
+            {activeCorruptionPenaltyPercent}% XP and gold
+          </span>
         </div>
       )}
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -43,6 +43,11 @@ export interface Quest {
   due_in_hours: number | null; // Hours until corruption (deadline = created_at + due_in_hours)
   due_date: string | null; // DEPRECATED: use due_in_hours instead
   corrupted_at: string | null;
+  effective_xp_reward: number | null; // Current user's reward preview after household corruption
+  effective_gold_reward: number | null;
+  corruption_debuff: number | null;
+  corrupted_quest_count: number;
+  corruption_debuff_active: boolean;
   template: QuestTemplate | null; // Null for standalone quests
   participants: QuestParticipant[];
 }


### PR DESCRIPTION
## What changed

- Add quest read reward preview fields for active household corruption: `effective_xp_reward`, `effective_gold_reward`, `corruption_debuff`, `corrupted_quest_count`, and `corruption_debuff_active`.
- Apply a flat `-20%` household corruption debuff whenever at least one active quest is corrupted; additional corrupted quests do not stack the penalty.
- Show adjusted XP/gold rewards and corruption context in the quest detail modal.
- Mark corrupted quests on the board and add a household corruption banner.
- Document the updated reward preview contract and flat corruption behavior.

## Why

Corrupted households were awarding reduced rewards on completion, but available quest details and board cards still showed base rewards. This made the displayed reward values disagree with what users actually received.

## Validation

- `uv run --extra dev pytest tests/test_quest_corruption.py tests/test_quests.py tests/test_bounty.py` -> 55 passed
- `bun run format:check`
- `bun run typecheck`
- `bun run build`
- `git diff --check`

## Deployment notes

No database migration is required. Backend and frontend should deploy together because the UI consumes the new quest read preview fields.