### PR TITLE
[codex] Add NFC trigger flow and staging support

### DIFF
--- a/backend/app/crud/quest_template.py
+++ b/backend/app/crud/quest_template.py
@@ -10,6 +10,16 @@ def get_quest_template(db: Session, template_id: int) -> Optional[QuestTemplate]
     return db.exec(select(QuestTemplate).where(QuestTemplate.id == template_id)).first()
 
 
+def get_nfc_quest_template(db: Session, nfc_code: str) -> Optional[QuestTemplate]:
+    """Get an NFC-enabled quest template by its public NFC code."""
+    return db.exec(
+        select(QuestTemplate).where(
+            (QuestTemplate.nfc_code == nfc_code)
+            & (QuestTemplate.nfc_enabled == True)  # noqa: E712
+        )
+    ).first()
+
+
 def get_home_quest_templates(db: Session, home_id: int, system: Optional[bool] = None) -> list[QuestTemplate]:
     """Get all quest templates for a home (optionally filtered by system)"""
     query = select(QuestTemplate).where(QuestTemplate.home_id == home_id)

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -31,12 +31,25 @@ def ensure_runtime_schema_compatibility() -> None:
         return
 
     column_names = {column["name"] for column in inspector.get_columns("quest")}
+    quest_template_column_names = (
+        {column["name"] for column in inspector.get_columns("quest_template")}
+        if "quest_template" in inspector.get_table_names()
+        else set()
+    )
 
     with engine.begin() as connection:
         if "created_by" not in column_names:
             connection.execute(text("ALTER TABLE quest ADD COLUMN created_by INTEGER"))
             connection.execute(text("UPDATE quest SET created_by = user_id WHERE created_by IS NULL"))
             connection.execute(text("CREATE INDEX IF NOT EXISTS ix_quest_created_by ON quest (created_by)"))
+
+        if "nfc_enabled" not in quest_template_column_names:
+            connection.execute(text("ALTER TABLE quest_template ADD COLUMN nfc_enabled BOOLEAN DEFAULT 0 NOT NULL"))
+            connection.execute(text("CREATE INDEX IF NOT EXISTS ix_quest_template_nfc_enabled ON quest_template (nfc_enabled)"))
+
+        if "nfc_code" not in quest_template_column_names:
+            connection.execute(text("ALTER TABLE quest_template ADD COLUMN nfc_code VARCHAR(128)"))
+            connection.execute(text("CREATE UNIQUE INDEX IF NOT EXISTS ix_quest_template_nfc_code ON quest_template (nfc_code)"))
 
         # Keep this idempotent backfill through the production rollout. It can be
         # removed in a later cleanup once every deployed database has the table

--- a/backend/app/models/quest.py
+++ b/backend/app/models/quest.py
@@ -27,6 +27,8 @@ class QuestTemplate(SQLModel, table=True):
     last_generated_at: Optional[datetime] = None  # when last instance was created
     due_in_hours: Optional[int] = Field(default=None, ge=1, le=8760)  # relative deadline (1h-1yr)
     system: bool = Field(default=False)  # true = system default, false = user created
+    nfc_enabled: bool = Field(default=False, index=True)
+    nfc_code: Optional[str] = Field(default=None, max_length=128, index=True, unique=True)
     created_by: int = Field(foreign_key="user.id")  # user who created it
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
@@ -87,6 +89,8 @@ class QuestTemplateRead(SQLModel):
     last_generated_at: Optional[datetime]
     due_in_hours: Optional[int]
     system: bool
+    nfc_enabled: bool
+    nfc_code: Optional[str]
     created_by: int
     created_at: datetime
 
@@ -104,6 +108,8 @@ class QuestTemplateCreate(SQLModel):
     recurrence: str = Field(default="one-off")
     schedule: Optional[str] = None
     due_in_hours: Optional[int] = Field(default=None, ge=1, le=8760)
+    nfc_enabled: bool = Field(default=False)
+    nfc_code: Optional[str] = Field(default=None, max_length=128)
 
 
 class QuestTemplateUpdate(SQLModel):
@@ -118,6 +124,8 @@ class QuestTemplateUpdate(SQLModel):
     recurrence: Optional[str] = Field(default=None)
     schedule: Optional[str] = None
     due_in_hours: Optional[int] = Field(default=None, ge=1, le=8760)
+    nfc_enabled: Optional[bool] = Field(default=None)
+    nfc_code: Optional[str] = Field(default=None, max_length=128)
 
 
 class Quest(SQLModel, table=True):

--- a/backend/app/routes/quest.py
+++ b/backend/app/routes/quest.py
@@ -2,11 +2,9 @@ from datetime import datetime, timezone
 from typing import Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
-from sqlmodel import Session, select
+from sqlmodel import Session
 
 from app.auth import get_current_user
-from app.crud import achievement as crud_achievement
-from app.crud import daily_bounty as crud_daily_bounty
 from app.crud import quest as crud_quest
 from app.crud import quest_template as crud_quest_template
 from app.crud import user as crud_user
@@ -23,62 +21,16 @@ from app.models.quest import (
     QuestTemplateUpdate,
     QuestUpdate,
 )
-from app.models.user import User
+from app.services.quest_completion import (
+    complete_quest_with_rewards,
+    corruption_multiplier,
+    get_corrupted_quest_count,
+    has_active_shield,
+)
 from app.services.recurring_quests import generate_due_quests
 from app.services.scribe import ScribeResponse, generate_quest_content
 
 router = APIRouter(prefix="/api/quests", tags=["quests"])
-
-CORRUPTION_DEBUFF_PERCENT = 20
-
-
-def _as_aware_datetime(value: datetime) -> datetime:
-    """Treat legacy naive datetimes as UTC so reward previews match completion."""
-    if value.tzinfo is None:
-        return value.replace(tzinfo=timezone.utc)
-    return value
-
-
-def _has_active_shield(user: User) -> bool:
-    if not user.active_shield_expiry:
-        return False
-
-    return _as_aware_datetime(user.active_shield_expiry) > datetime.now(timezone.utc)
-
-
-def _get_corrupted_quest_count(db: Session, home_id: int) -> int:
-    corrupted_quests = db.exec(
-        select(Quest.id).where(
-            (Quest.home_id == home_id)
-            & (Quest.quest_type == "corrupted")
-            & (Quest.completed == False)  # noqa: E712
-        )
-    ).all()
-    return len(corrupted_quests)
-
-
-def _corruption_multiplier(corrupted_quest_count: int) -> float:
-    if corrupted_quest_count <= 0:
-        return 1.0
-
-    return 1.0 - (CORRUPTION_DEBUFF_PERCENT / 100.0)
-
-
-def _calculate_corruption_debuff(db: Session, home_id: int, user: User) -> float:
-    """
-    Calculate house-wide corruption debuff multiplier.
-
-    Returns multiplier to apply to rewards (1.0 = no debuff, 0.8 = -20% debuff, etc.)
-
-    Debuff calculation:
-    - Any active corrupted quest in the home applies a flat -20% penalty
-    - Additional corrupted quests do not increase the penalty
-    - Shield suppresses debuff temporarily (returns 1.0 if active)
-    """
-    if _has_active_shield(user):
-        return 1.0  # No debuff - shield protects
-
-    return _corruption_multiplier(_get_corrupted_quest_count(db, home_id))
 
 
 def _get_quest_reward_preview_context(db: Session, auth: dict) -> tuple[int, float]:
@@ -89,11 +41,11 @@ def _get_quest_reward_preview_context(db: Session, auth: dict) -> tuple[int, flo
             detail=create_error_detail(ErrorCode.USER_NOT_FOUND, details={"user_id": auth["user_id"]}),
         )
 
-    corrupted_quest_count = _get_corrupted_quest_count(db, auth["home_id"])
-    if _has_active_shield(user):
+    corrupted_quest_count = get_corrupted_quest_count(db, auth["home_id"])
+    if has_active_shield(user):
         return corrupted_quest_count, 1.0
 
-    return corrupted_quest_count, _corruption_multiplier(corrupted_quest_count)
+    return corrupted_quest_count, corruption_multiplier(corrupted_quest_count)
 
 
 def _quest_to_read(quest: Quest, corrupted_quest_count: int, corruption_debuff: float) -> QuestRead:
@@ -472,154 +424,7 @@ def complete_quest(quest_id: int, db: Session = Depends(get_db), auth: dict = De
             detail=create_error_detail(ErrorCode.QUEST_NOT_FOUND, details={"quest_id": quest_id}),
         )
 
-    # Prevent double-completion
-    if quest.completed:
-        raise HTTPException(
-            status_code=400,
-            detail=create_error_detail(
-                ErrorCode.QUEST_ALREADY_COMPLETED,
-                details={
-                    "quest_id": quest_id,
-                    "completed_at": quest.completed_at.isoformat() if quest.completed_at else None,
-                },
-            ),
-        )
-
-    participants = crud_quest.ensure_quest_participants(db, quest)
-    if not participants:
-        raise HTTPException(status_code=400, detail="Quest has no participants")
-
-    participants = sorted(participants, key=lambda participant: participant.user_id)
-    participant_users: dict[int, User] = {}
-    for participant in participants:
-        participant_user = crud_user.get_user(db, participant.user_id)
-        if not participant_user or participant_user.home_id != auth["home_id"]:
-            raise HTTPException(
-                status_code=404,
-                detail=create_error_detail(ErrorCode.USER_NOT_FOUND, details={"user_id": participant.user_id}),
-            )
-        participant_users[participant.user_id] = participant_user
-
-    # Check if quest is corrupted (overdue) - for display purposes only (not bonus rewards)
-    is_corrupted = quest.quest_type == "corrupted"
-
-    base_xp = quest.xp_reward
-    base_gold = quest.gold_reward
-    completed_at = datetime.now(timezone.utc)
-    bounty_decisions = {
-        participant.user_id: crud_daily_bounty.get_or_create_today_bounty(db, auth["home_id"], participant.user_id)
-        for participant in participants
-    }
-
-    participant_reward_breakdowns = []
-    total_xp_awarded = 0
-    total_gold_awarded = 0
-    any_daily_bounty = False
-    any_xp_boost = False
-    first_participant_xp_boost_remaining = 0
-
-    for index, participant in enumerate(participants):
-        user = participant_users[participant.user_id]
-
-        today_bounty = bounty_decisions[user.id]
-        is_daily_bounty = bool(today_bounty.status == "assigned" and today_bounty.quest_id == quest.id)
-        any_daily_bounty = any_daily_bounty or is_daily_bounty
-
-        corruption_debuff_multiplier = _calculate_corruption_debuff(db, auth["home_id"], user)
-        has_xp_boost = user.active_xp_boost_count > 0
-        any_xp_boost = any_xp_boost or has_xp_boost
-
-        participant_base_xp = base_xp
-        participant_base_gold = base_gold
-        bounty_gold_multiplier = 3 if is_daily_bounty else 1
-        bounty_xp_multiplier = 1
-        xp_boost_multiplier = 2 if has_xp_boost else 1
-
-        xp_after_debuff = participant_base_xp * corruption_debuff_multiplier
-        gold_after_debuff = participant_base_gold * corruption_debuff_multiplier
-        xp_after_bounty = xp_after_debuff * bounty_xp_multiplier
-        gold_after_bounty = gold_after_debuff * bounty_gold_multiplier
-        xp_awarded = int(xp_after_bounty * xp_boost_multiplier)
-        gold_awarded = int(gold_after_bounty)
-
-        participant.xp_awarded = xp_awarded
-        participant.gold_awarded = gold_awarded
-        participant.completed_at = completed_at
-        db.add(participant)
-
-        user.xp += xp_awarded
-        user.level = crud_user.calculate_level(user.xp)
-        user.gold_balance += gold_awarded
-
-        if has_xp_boost:
-            user.active_xp_boost_count -= 1
-
-        db.add(user)
-
-        if index == 0:
-            first_participant_xp_boost_remaining = user.active_xp_boost_count
-
-        total_xp_awarded += xp_awarded
-        total_gold_awarded += gold_awarded
-        participant_reward_breakdowns.append(
-            {
-                "user_id": user.id,
-                "xp": xp_awarded,
-                "gold": gold_awarded,
-                "base_xp": participant_base_xp,
-                "base_gold": participant_base_gold,
-                "is_daily_bounty": is_daily_bounty,
-                "is_corrupted": is_corrupted,
-                "corruption_debuff": corruption_debuff_multiplier,
-                "bounty_multiplier": bounty_gold_multiplier,
-                "bounty_gold_multiplier": bounty_gold_multiplier,
-                "bounty_xp_multiplier": bounty_xp_multiplier,
-                "xp_boost_active": has_xp_boost,
-                "xp_boost_remaining": user.active_xp_boost_count,
-            }
-        )
-
-    quest.completed = True
-    quest.completed_at = completed_at
-    db.add(quest)
-
-    db.commit()
-    db.refresh(quest)
-
-    # Check and award any newly earned achievements
-    newly_awarded_achievements = []
-    for participant in participants:
-        for user_achievement in crud_achievement.check_and_award_achievements(db, participant.user_id):
-            newly_awarded_achievements.append(
-                {
-                    "user_id": participant.user_id,
-                    "id": user_achievement.achievement_id,
-                    "unlocked_at": user_achievement.unlocked_at,
-                }
-            )
-
-    return {
-        "quest": QuestRead.model_validate(quest),
-        "rewards": {
-            "xp": total_xp_awarded,
-            "gold": total_gold_awarded,
-            "base_xp": base_xp,
-            "base_gold": base_gold,
-            "is_daily_bounty": any_daily_bounty,
-            "is_corrupted": is_corrupted,
-            "corruption_debuff": min(
-                (reward["corruption_debuff"] for reward in participant_reward_breakdowns),
-                default=1.0,
-            ),
-            "bounty_multiplier": 3 if any_daily_bounty else 1,
-            "bounty_gold_multiplier": 3 if any_daily_bounty else 1,
-            "bounty_xp_multiplier": 1,
-            "xp_boost_active": any_xp_boost,
-            "xp_boost_remaining": first_participant_xp_boost_remaining,
-            "participants": participant_reward_breakdowns,
-        },
-        "achievements": newly_awarded_achievements,
-    }
+    return complete_quest_with_rewards(db, quest, auth)
 
 
 def _validate_quest_schedule(recurrence: str, schedule: Optional[str]) -> None:

--- a/backend/app/routes/triggers.py
+++ b/backend/app/routes/triggers.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import Session, select
@@ -53,7 +54,7 @@ def _find_recent_completed_user_quest_for_template(
     user_id: int,
     quest_template_id: int,
     now: datetime,
-) -> Quest | None:
+) -> Optional[Quest]:
     cooldown_cutoff = now - timedelta(seconds=NFC_DUPLICATE_SCAN_COOLDOWN_SECONDS)
     return db.exec(
         select(Quest)

--- a/backend/app/routes/triggers.py
+++ b/backend/app/routes/triggers.py
@@ -1,39 +1,183 @@
+from datetime import datetime, timedelta, timezone
+
 from fastapi import APIRouter, Depends, HTTPException
-from sqlmodel import Session
+from sqlmodel import Session, select
 
 from app.auth import get_current_user
 from app.crud import quest as crud_quest
 from app.crud import quest_template as crud_quest_template
 from app.crud import user as crud_user
 from app.database import get_db
-from app.models.quest import QuestCreate, QuestRead
+from app.models.quest import Quest, QuestCreate, QuestParticipant, QuestRead
+from app.services.quest_completion import as_aware_datetime, complete_quest_with_rewards
 
 router = APIRouter(prefix="/api/triggers", tags=["triggers"])
 
+NFC_DUPLICATE_SCAN_COOLDOWN_SECONDS = 30
 
-@router.post("/quest/{quest_template_id}")
-def trigger_quest(
+
+def _get_user_stats(db: Session, auth: dict) -> dict:
+    user = crud_user.get_user(db, auth["user_id"])
+    if not user or user.home_id != auth["home_id"]:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    return {
+        "level": user.level,
+        "xp": user.xp,
+        "gold": user.gold_balance,
+    }
+
+
+def _find_active_user_quest_for_template(
+    db: Session,
+    home_id: int,
+    user_id: int,
     quest_template_id: int,
+) -> list[Quest]:
+    return db.exec(
+        select(Quest)
+        .join(QuestParticipant, QuestParticipant.quest_id == Quest.id)
+        .where(
+            (Quest.home_id == home_id)
+            & (Quest.quest_template_id == quest_template_id)
+            & (Quest.completed == False)  # noqa: E712
+            & (QuestParticipant.user_id == user_id)
+        )
+        .order_by(Quest.created_at.asc())
+    ).all()
+
+
+def _find_recent_completed_user_quest_for_template(
+    db: Session,
+    home_id: int,
+    user_id: int,
+    quest_template_id: int,
+    now: datetime,
+) -> Quest | None:
+    cooldown_cutoff = now - timedelta(seconds=NFC_DUPLICATE_SCAN_COOLDOWN_SECONDS)
+    return db.exec(
+        select(Quest)
+        .join(QuestParticipant, QuestParticipant.quest_id == Quest.id)
+        .where(
+            (Quest.home_id == home_id)
+            & (Quest.quest_template_id == quest_template_id)
+            & (Quest.completed == True)  # noqa: E712
+            & (Quest.completed_at >= cooldown_cutoff)
+            & (QuestParticipant.user_id == user_id)
+        )
+        .order_by(Quest.completed_at.desc())
+    ).first()
+
+
+def _cooldown_remaining_seconds(quest: Quest, now: datetime) -> int:
+    if not quest.completed_at:
+        return NFC_DUPLICATE_SCAN_COOLDOWN_SECONDS
+
+    completed_at = as_aware_datetime(quest.completed_at)
+    elapsed_seconds = max(0, int((now - completed_at).total_seconds()))
+    return max(1, NFC_DUPLICATE_SCAN_COOLDOWN_SECONDS - elapsed_seconds)
+
+
+def _duplicate_scan_response(db: Session, quest: Quest, auth: dict, now: datetime) -> dict:
+    participants = crud_quest.ensure_quest_participants(db, quest)
+    participant = next((item for item in participants if item.user_id == auth["user_id"]), None)
+    previous_xp = participant.xp_awarded if participant and participant.xp_awarded is not None else 0
+    previous_gold = participant.gold_awarded if participant and participant.gold_awarded is not None else 0
+
+    return {
+        "success": True,
+        "duplicate": True,
+        "source": "cooldown",
+        "cooldown_seconds": NFC_DUPLICATE_SCAN_COOLDOWN_SECONDS,
+        "cooldown_remaining_seconds": _cooldown_remaining_seconds(quest, now),
+        "quest": QuestRead.model_validate(quest),
+        "user_stats": _get_user_stats(db, auth),
+        "rewards": {
+            "xp": 0,
+            "gold": 0,
+            "base_xp": quest.xp_reward,
+            "base_gold": quest.gold_reward,
+            "is_daily_bounty": False,
+            "is_corrupted": quest.quest_type == "corrupted",
+            "corruption_debuff": 1.0,
+            "bounty_multiplier": 1,
+            "bounty_gold_multiplier": 1,
+            "bounty_xp_multiplier": 1,
+            "xp_boost_active": False,
+            "xp_boost_remaining": 0,
+            "duplicate_scan": True,
+            "previous_xp": previous_xp,
+            "previous_gold": previous_gold,
+        },
+        "achievements": [],
+    }
+
+
+def _completion_response(db: Session, quest: Quest, auth: dict, source: str) -> dict:
+    completion = complete_quest_with_rewards(db, quest, auth)
+    return {
+        "success": True,
+        "duplicate": False,
+        "source": source,
+        "cooldown_seconds": NFC_DUPLICATE_SCAN_COOLDOWN_SECONDS,
+        **completion,
+        "user_stats": _get_user_stats(db, auth),
+    }
+
+
+def _is_shared_quest(db: Session, quest: Quest) -> bool:
+    participants = crud_quest.ensure_quest_participants(db, quest)
+    return len(participants) > 1
+
+
+@router.post("/nfc/{nfc_code}")
+def trigger_quest(
+    nfc_code: str,
     db: Session = Depends(get_db),
     auth: dict = Depends(get_current_user),
 ) -> dict:
     """
     Trigger quest completion via NFC or manual trigger.
-    - Creates a new quest instance from template
-    - Completes it immediately
-    - Awards XP and gold
+    - Completes the user's oldest active quest for this template when one exists
+    - Otherwise creates a new quest instance from the template and completes it
+    - Suppresses duplicate scans for a short cooldown window
     - Returns quest and rewards
     """
-    # Get template
-    template = crud_quest_template.get_quest_template(db, quest_template_id)
-    if not template:
-        raise HTTPException(status_code=404, detail="Quest template not found")
+    template = crud_quest_template.get_nfc_quest_template(db, nfc_code)
+    if not template or template.home_id != auth["home_id"]:
+        raise HTTPException(status_code=404, detail="NFC trigger not found")
 
-    # Verify template belongs to user's home
-    if template.home_id != auth["home_id"]:
-        raise HTTPException(status_code=403, detail="Not authorized to trigger this quest")
+    quest_template_id = template.id
+    if quest_template_id is None:
+        raise HTTPException(status_code=404, detail="NFC trigger not found")
 
-    # Create quest instance with snapshot of template data
+    now = datetime.now(timezone.utc)
+    recent_quest = _find_recent_completed_user_quest_for_template(
+        db,
+        auth["home_id"],
+        auth["user_id"],
+        quest_template_id,
+        now,
+    )
+    if recent_quest:
+        return _duplicate_scan_response(db, recent_quest, auth, now)
+
+    active_quests = _find_active_user_quest_for_template(
+        db,
+        auth["home_id"],
+        auth["user_id"],
+        quest_template_id,
+    )
+    for active_quest in active_quests:
+        if not _is_shared_quest(db, active_quest):
+            return _completion_response(db, active_quest, auth, "active_quest")
+
+    if active_quests:
+        raise HTTPException(
+            status_code=409,
+            detail="This is a shared quest. Complete it from the board.",
+        )
+
     quest_in = QuestCreate(quest_template_id=quest_template_id)
     quest = crud_quest.create_quest(
         db,
@@ -44,33 +188,4 @@ def trigger_quest(
         template,
     )
 
-    # Complete the quest immediately with base rewards (no multipliers applied for NFC triggers)
-    base_xp = quest.xp_reward
-    base_gold = quest.gold_reward
-    quest = crud_quest.complete_quest(db, quest.id, final_xp=base_xp, final_gold=base_gold)
-    participants = crud_quest.ensure_quest_participants(db, quest)
-    for participant in participants:
-        if participant.user_id == auth["user_id"]:
-            participant.xp_awarded = base_xp
-            participant.gold_awarded = base_gold
-            participant.completed_at = quest.completed_at
-            db.add(participant)
-    db.commit()
-
-    # Award XP and gold
-    user = crud_user.add_xp(db, auth["user_id"], base_xp)
-    user = crud_user.add_gold(db, auth["user_id"], base_gold)
-
-    return {
-        "success": True,
-        "quest": QuestRead.model_validate(quest),
-        "user_stats": {
-            "level": user.level,
-            "xp": user.xp,
-            "gold": user.gold_balance,
-        },
-        "rewards": {
-            "xp": base_xp,
-            "gold": base_gold,
-        },
-    }
+    return _completion_response(db, quest, auth, "created_from_template")

--- a/backend/app/services/quest_completion.py
+++ b/backend/app/services/quest_completion.py
@@ -1,0 +1,220 @@
+from datetime import datetime, timezone
+
+from fastapi import HTTPException
+from sqlmodel import Session, select
+
+from app.crud import achievement as crud_achievement
+from app.crud import daily_bounty as crud_daily_bounty
+from app.crud import quest as crud_quest
+from app.crud import user as crud_user
+from app.errors import ErrorCode, create_error_detail
+from app.models.quest import Quest, QuestRead
+from app.models.user import User
+
+CORRUPTION_DEBUFF_PERCENT = 20
+
+
+def as_aware_datetime(value: datetime) -> datetime:
+    """Treat legacy naive datetimes as UTC so reward logic remains consistent."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value
+
+
+def has_active_shield(user: User) -> bool:
+    if not user.active_shield_expiry:
+        return False
+
+    return as_aware_datetime(user.active_shield_expiry) > datetime.now(timezone.utc)
+
+
+def get_corrupted_quest_count(db: Session, home_id: int) -> int:
+    corrupted_quests = db.exec(
+        select(Quest.id).where(
+            (Quest.home_id == home_id)
+            & (Quest.quest_type == "corrupted")
+            & (Quest.completed == False)  # noqa: E712
+        )
+    ).all()
+    return len(corrupted_quests)
+
+
+def corruption_multiplier(corrupted_quest_count: int) -> float:
+    if corrupted_quest_count <= 0:
+        return 1.0
+
+    return 1.0 - (CORRUPTION_DEBUFF_PERCENT / 100.0)
+
+
+def calculate_corruption_debuff(db: Session, home_id: int, user: User) -> float:
+    """
+    Calculate house-wide corruption debuff multiplier.
+
+    Debuff calculation:
+    - Any active corrupted quest in the home applies a flat -20% penalty
+    - Additional corrupted quests do not increase the penalty
+    - Shield suppresses debuff temporarily
+    """
+    if has_active_shield(user):
+        return 1.0
+
+    return corruption_multiplier(get_corrupted_quest_count(db, home_id))
+
+
+def complete_quest_with_rewards(db: Session, quest: Quest, auth: dict) -> dict:
+    """
+    Complete a quest and award rewards to every participant.
+
+    This is shared by board completion and NFC/template triggers so reward
+    rules do not drift between entry points.
+    """
+    if quest.home_id != auth["home_id"]:
+        raise HTTPException(
+            status_code=404,
+            detail=create_error_detail(ErrorCode.QUEST_NOT_FOUND, details={"quest_id": quest.id}),
+        )
+
+    if quest.completed:
+        raise HTTPException(
+            status_code=400,
+            detail=create_error_detail(
+                ErrorCode.QUEST_ALREADY_COMPLETED,
+                details={
+                    "quest_id": quest.id,
+                    "completed_at": quest.completed_at.isoformat() if quest.completed_at else None,
+                },
+            ),
+        )
+
+    participants = crud_quest.ensure_quest_participants(db, quest)
+    if not participants:
+        raise HTTPException(status_code=400, detail="Quest has no participants")
+
+    participants = sorted(participants, key=lambda participant: participant.user_id)
+    participant_users: dict[int, User] = {}
+    for participant in participants:
+        participant_user = crud_user.get_user(db, participant.user_id)
+        if not participant_user or participant_user.home_id != auth["home_id"]:
+            raise HTTPException(
+                status_code=404,
+                detail=create_error_detail(ErrorCode.USER_NOT_FOUND, details={"user_id": participant.user_id}),
+            )
+        participant_users[participant.user_id] = participant_user
+
+    is_corrupted = quest.quest_type == "corrupted"
+    base_xp = quest.xp_reward
+    base_gold = quest.gold_reward
+    completed_at = datetime.now(timezone.utc)
+    bounty_decisions = {
+        participant.user_id: crud_daily_bounty.get_or_create_today_bounty(db, auth["home_id"], participant.user_id)
+        for participant in participants
+    }
+
+    participant_reward_breakdowns = []
+    total_xp_awarded = 0
+    total_gold_awarded = 0
+    any_daily_bounty = False
+    any_xp_boost = False
+    first_participant_xp_boost_remaining = 0
+
+    for index, participant in enumerate(participants):
+        user = participant_users[participant.user_id]
+
+        today_bounty = bounty_decisions[user.id]
+        is_daily_bounty = bool(today_bounty.status == "assigned" and today_bounty.quest_id == quest.id)
+        any_daily_bounty = any_daily_bounty or is_daily_bounty
+
+        corruption_debuff = calculate_corruption_debuff(db, auth["home_id"], user)
+        has_xp_boost = user.active_xp_boost_count > 0
+        any_xp_boost = any_xp_boost or has_xp_boost
+
+        participant_base_xp = base_xp
+        participant_base_gold = base_gold
+        bounty_gold_multiplier = 3 if is_daily_bounty else 1
+        bounty_xp_multiplier = 1
+        xp_boost_multiplier = 2 if has_xp_boost else 1
+
+        xp_after_debuff = participant_base_xp * corruption_debuff
+        gold_after_debuff = participant_base_gold * corruption_debuff
+        xp_after_bounty = xp_after_debuff * bounty_xp_multiplier
+        gold_after_bounty = gold_after_debuff * bounty_gold_multiplier
+        xp_awarded = int(xp_after_bounty * xp_boost_multiplier)
+        gold_awarded = int(gold_after_bounty)
+
+        participant.xp_awarded = xp_awarded
+        participant.gold_awarded = gold_awarded
+        participant.completed_at = completed_at
+        db.add(participant)
+
+        user.xp += xp_awarded
+        user.level = crud_user.calculate_level(user.xp)
+        user.gold_balance += gold_awarded
+
+        if has_xp_boost:
+            user.active_xp_boost_count -= 1
+
+        db.add(user)
+
+        if index == 0:
+            first_participant_xp_boost_remaining = user.active_xp_boost_count
+
+        total_xp_awarded += xp_awarded
+        total_gold_awarded += gold_awarded
+        participant_reward_breakdowns.append(
+            {
+                "user_id": user.id,
+                "xp": xp_awarded,
+                "gold": gold_awarded,
+                "base_xp": participant_base_xp,
+                "base_gold": participant_base_gold,
+                "is_daily_bounty": is_daily_bounty,
+                "is_corrupted": is_corrupted,
+                "corruption_debuff": corruption_debuff,
+                "bounty_multiplier": bounty_gold_multiplier,
+                "bounty_gold_multiplier": bounty_gold_multiplier,
+                "bounty_xp_multiplier": bounty_xp_multiplier,
+                "xp_boost_active": has_xp_boost,
+                "xp_boost_remaining": user.active_xp_boost_count,
+            }
+        )
+
+    quest.completed = True
+    quest.completed_at = completed_at
+    db.add(quest)
+
+    db.commit()
+    db.refresh(quest)
+
+    newly_awarded_achievements = []
+    for participant in participants:
+        for user_achievement in crud_achievement.check_and_award_achievements(db, participant.user_id):
+            newly_awarded_achievements.append(
+                {
+                    "user_id": participant.user_id,
+                    "id": user_achievement.achievement_id,
+                    "unlocked_at": user_achievement.unlocked_at,
+                }
+            )
+
+    return {
+        "quest": QuestRead.model_validate(quest),
+        "rewards": {
+            "xp": total_xp_awarded,
+            "gold": total_gold_awarded,
+            "base_xp": base_xp,
+            "base_gold": base_gold,
+            "is_daily_bounty": any_daily_bounty,
+            "is_corrupted": is_corrupted,
+            "corruption_debuff": min(
+                (reward["corruption_debuff"] for reward in participant_reward_breakdowns),
+                default=1.0,
+            ),
+            "bounty_multiplier": 3 if any_daily_bounty else 1,
+            "bounty_gold_multiplier": 3 if any_daily_bounty else 1,
+            "bounty_xp_multiplier": 1,
+            "xp_boost_active": any_xp_boost,
+            "xp_boost_remaining": first_participant_xp_boost_remaining,
+            "participants": participant_reward_breakdowns,
+        },
+        "achievements": newly_awarded_achievements,
+    }

--- a/backend/tests/test_triggers.py
+++ b/backend/tests/test_triggers.py
@@ -1,15 +1,18 @@
+from datetime import datetime, timedelta, timezone
+
 import pytest
 from fastapi.testclient import TestClient
-from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel import Session, SQLModel, create_engine, select
 from sqlmodel.pool import StaticPool
 
 from app.crud import home as crud_home
+from app.crud import quest as crud_quest
 from app.crud import quest_template as crud_quest_template
 from app.crud import user as crud_user
 from app.database import get_db
 from app.main import app
 from app.models.home import HomeCreate
-from app.models.quest import QuestTemplateCreate
+from app.models.quest import Quest, QuestCreate, QuestParticipant, QuestTemplateCreate
 from app.models.user import UserCreate
 
 
@@ -57,6 +60,8 @@ def setup_test_data(session: Session):
         xp_reward=25,
         gold_reward=15,
         quest_type="standard",
+        nfc_enabled=True,
+        nfc_code="clean-kitchen",
     )
     template = crud_quest_template.create_quest_template(session, home.id, alice.id, template_data)
 
@@ -78,12 +83,15 @@ def test_trigger_quest_success(client: TestClient, session: Session):
     initial_gold = response.json()["gold_balance"]
 
     # Trigger quest
-    response = client.post(f"/api/triggers/quest/{template.id}", headers={"Authorization": f"Bearer {token}"})
+    response = client.post("/api/triggers/nfc/clean-kitchen", headers={"Authorization": f"Bearer {token}"})
     assert response.status_code == 200
     data = response.json()
 
     # Verify response
     assert data["success"] is True
+    assert data["duplicate"] is False
+    assert data["source"] == "created_from_template"
+    assert data["cooldown_seconds"] == 30
     assert data["quest"]["completed"] is True
     assert data["quest"]["template"]["id"] == template.id
     assert data["rewards"]["xp"] == 25
@@ -92,16 +100,15 @@ def test_trigger_quest_success(client: TestClient, session: Session):
     assert data["user_stats"]["gold"] == initial_gold + 15
 
 
-def test_trigger_quest_not_found(client: TestClient, session: Session):
-    """Test trigger with non-existent template"""
+def test_trigger_nfc_code_not_found(client: TestClient, session: Session):
+    """Test trigger with non-existent NFC code"""
     home, alice, _ = setup_test_data(session)
 
     # Login
     response = client.post("/api/auth/login", json={"home_id": home.id, "username": "alice", "password": "alice123"})
     token = response.json()["access_token"]
 
-    # Try to trigger non-existent quest
-    response = client.post("/api/triggers/quest/9999", headers={"Authorization": f"Bearer {token}"})
+    response = client.post("/api/triggers/nfc/not-a-real-code", headers={"Authorization": f"Bearer {token}"})
     assert response.status_code == 404
     error_detail = response.json()["detail"]
     # Support both old (string) and new (dict) error formats
@@ -116,12 +123,12 @@ def test_trigger_quest_unauthorized(client: TestClient, session: Session):
     home, alice, template = setup_test_data(session)
 
     # Try to trigger without token
-    response = client.post(f"/api/triggers/quest/{template.id}")
+    response = client.post("/api/triggers/nfc/clean-kitchen")
     assert response.status_code == 401
 
 
 def test_trigger_quest_wrong_home(client: TestClient, session: Session):
-    """Test trigger quest from different home"""
+    """Test trigger NFC code from a different home"""
     home1, alice, template = setup_test_data(session)
 
     # Create second home and user
@@ -134,19 +141,154 @@ def test_trigger_quest_wrong_home(client: TestClient, session: Session):
     response = client.post("/api/auth/login", json={"home_id": home2.id, "username": "bob", "password": "bob123"})
     token = response.json()["access_token"]
 
-    # Try to trigger quest from different home
-    response = client.post(f"/api/triggers/quest/{template.id}", headers={"Authorization": f"Bearer {token}"})
-    assert response.status_code == 403
+    # Try to trigger NFC code from different home
+    response = client.post("/api/triggers/nfc/clean-kitchen", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 404
     error_detail = response.json()["detail"]
-    # Support both old (string) and new (dict) error formats
-    if isinstance(error_detail, dict):
-        assert "not authorized" in error_detail["message"].lower() or error_detail["code"] == "UNAUTHORIZED_ACCESS"
-    else:
-        assert "not authorized" in error_detail.lower()
+    assert "not found" in error_detail.lower()
 
 
-def test_trigger_multiple_times(client: TestClient, session: Session):
-    """Test triggering same quest multiple times creates separate instances"""
+def test_trigger_disabled_template_not_found(client: TestClient, session: Session):
+    """Test templates must be explicitly NFC-enabled before a code can trigger them."""
+    home, alice, _ = setup_test_data(session)
+    disabled_template = crud_quest_template.create_quest_template(
+        session,
+        home.id,
+        alice.id,
+        QuestTemplateCreate(
+            title="Disabled NFC",
+            xp_reward=10,
+            gold_reward=5,
+            nfc_enabled=False,
+            nfc_code="disabled-nfc",
+        ),
+    )
+
+    response = client.post("/api/auth/login", json={"home_id": home.id, "username": "alice", "password": "alice123"})
+    token = response.json()["access_token"]
+
+    response = client.post("/api/triggers/nfc/disabled-nfc", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 404
+    assert response.json()["detail"] == "NFC trigger not found"
+
+    assert disabled_template.nfc_enabled is False
+
+
+def test_legacy_template_id_trigger_route_removed(client: TestClient, session: Session):
+    """Test the old implementation-detail route is no longer exposed."""
+    home, _, template = setup_test_data(session)
+
+    response = client.post("/api/auth/login", json={"home_id": home.id, "username": "alice", "password": "alice123"})
+    token = response.json()["access_token"]
+
+    response = client.post(f"/api/triggers/quest/{template.id}", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 404
+
+
+def test_trigger_completes_existing_active_template_quest(client: TestClient, session: Session):
+    """Test NFC completes the oldest active matching quest instead of creating a duplicate."""
+    home, alice, template = setup_test_data(session)
+    quest = crud_quest.create_quest(
+        session,
+        home.id,
+        alice.id,
+        [alice.id],
+        QuestCreate(quest_template_id=template.id),
+        template,
+    )
+
+    response = client.post("/api/auth/login", json={"home_id": home.id, "username": "alice", "password": "alice123"})
+    token = response.json()["access_token"]
+
+    response = client.post("/api/triggers/nfc/clean-kitchen", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["success"] is True
+    assert data["duplicate"] is False
+    assert data["source"] == "active_quest"
+    assert data["quest"]["id"] == quest.id
+    assert data["quest"]["completed"] is True
+    assert data["rewards"]["xp"] == 25
+    assert data["rewards"]["gold"] == 15
+
+    quests = session.exec(select(Quest).where(Quest.quest_template_id == template.id)).all()
+    assert len(quests) == 1
+
+
+def test_trigger_rejects_shared_active_template_quest(client: TestClient, session: Session):
+    """Test NFC does not complete shared active quests."""
+    home, alice, template = setup_test_data(session)
+    bob = crud_user.create_user(session, home.id, UserCreate(username="bob", password="bob123"))
+    quest = crud_quest.create_quest(
+        session,
+        home.id,
+        alice.id,
+        [alice.id, bob.id],
+        QuestCreate(quest_template_id=template.id),
+        template,
+    )
+
+    response = client.post("/api/auth/login", json={"home_id": home.id, "username": "alice", "password": "alice123"})
+    token = response.json()["access_token"]
+
+    response = client.post("/api/triggers/nfc/clean-kitchen", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 409
+    assert response.json()["detail"] == "This is a shared quest. Complete it from the board."
+
+    persisted_quest = session.get(Quest, quest.id)
+    assert persisted_quest is not None
+    assert persisted_quest.completed is False
+
+    response = client.get("/api/users/me", headers={"Authorization": f"Bearer {token}"})
+    user = response.json()
+    assert user["xp"] == 0
+    assert user["gold_balance"] == 0
+
+
+def test_trigger_prefers_personal_active_template_quest_over_shared_one(
+    client: TestClient, session: Session
+):
+    """Test NFC completes a personal quest even if an older shared match also exists."""
+    home, alice, template = setup_test_data(session)
+    bob = crud_user.create_user(session, home.id, UserCreate(username="bob", password="bob123"))
+    shared_quest = crud_quest.create_quest(
+        session,
+        home.id,
+        alice.id,
+        [alice.id, bob.id],
+        QuestCreate(quest_template_id=template.id),
+        template,
+    )
+    personal_quest = crud_quest.create_quest(
+        session,
+        home.id,
+        alice.id,
+        [alice.id],
+        QuestCreate(quest_template_id=template.id),
+        template,
+    )
+
+    response = client.post("/api/auth/login", json={"home_id": home.id, "username": "alice", "password": "alice123"})
+    token = response.json()["access_token"]
+
+    response = client.post("/api/triggers/nfc/clean-kitchen", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["source"] == "active_quest"
+    assert data["quest"]["id"] == personal_quest.id
+
+    persisted_shared_quest = session.get(Quest, shared_quest.id)
+    persisted_personal_quest = session.get(Quest, personal_quest.id)
+    assert persisted_shared_quest is not None
+    assert persisted_personal_quest is not None
+    assert persisted_shared_quest.completed is False
+    assert persisted_personal_quest.completed is True
+
+
+def test_trigger_duplicate_scan_within_cooldown_does_not_award_again(client: TestClient, session: Session):
+    """Test repeated scans within 30 seconds return a duplicate response without rewards."""
     home, alice, template = setup_test_data(session)
 
     # Login
@@ -154,22 +296,71 @@ def test_trigger_multiple_times(client: TestClient, session: Session):
     token = response.json()["access_token"]
 
     # Trigger twice
-    response1 = client.post(f"/api/triggers/quest/{template.id}", headers={"Authorization": f"Bearer {token}"})
-    response2 = client.post(f"/api/triggers/quest/{template.id}", headers={"Authorization": f"Bearer {token}"})
+    response1 = client.post("/api/triggers/nfc/clean-kitchen", headers={"Authorization": f"Bearer {token}"})
+    response2 = client.post("/api/triggers/nfc/clean-kitchen", headers={"Authorization": f"Bearer {token}"})
 
     assert response1.status_code == 200
     assert response2.status_code == 200
 
-    # Both should be completed
-    quest1 = response1.json()["quest"]
-    quest2 = response2.json()["quest"]
+    data1 = response1.json()
+    data2 = response2.json()
 
-    assert quest1["id"] != quest2["id"]
-    assert quest1["completed"] is True
-    assert quest2["completed"] is True
+    assert data1["duplicate"] is False
+    assert data2["duplicate"] is True
+    assert data2["source"] == "cooldown"
+    assert data2["cooldown_remaining_seconds"] > 0
+    assert data2["quest"]["id"] == data1["quest"]["id"]
+    assert data2["quest"]["completed"] is True
+    assert data2["rewards"]["xp"] == 0
+    assert data2["rewards"]["gold"] == 0
+    assert data2["rewards"]["previous_xp"] == 25
+    assert data2["rewards"]["previous_gold"] == 15
 
-    # User should have double rewards
+    # User should only receive rewards once
     response = client.get("/api/users/me", headers={"Authorization": f"Bearer {token}"})
     user = response.json()
-    assert user["xp"] == 50  # 25 * 2
-    assert user["gold_balance"] == 30  # 15 * 2
+    assert user["xp"] == 25
+    assert user["gold_balance"] == 15
+
+
+def test_trigger_after_cooldown_creates_new_instance(client: TestClient, session: Session):
+    """Test scans after the cooldown window keep the old create-and-complete behavior."""
+    home, alice, template = setup_test_data(session)
+
+    response = client.post("/api/auth/login", json={"home_id": home.id, "username": "alice", "password": "alice123"})
+    token = response.json()["access_token"]
+
+    response1 = client.post("/api/triggers/nfc/clean-kitchen", headers={"Authorization": f"Bearer {token}"})
+    assert response1.status_code == 200
+    first_quest_id = response1.json()["quest"]["id"]
+
+    completed_at = datetime.now(timezone.utc) - timedelta(seconds=31)
+    quest = session.get(Quest, first_quest_id)
+    assert quest is not None
+    quest.completed_at = completed_at
+    session.add(quest)
+
+    participant = session.exec(
+        select(QuestParticipant).where(
+            (QuestParticipant.quest_id == first_quest_id) & (QuestParticipant.user_id == alice.id)
+        )
+    ).first()
+    assert participant is not None
+    participant.completed_at = completed_at
+    session.add(participant)
+    session.commit()
+
+    response2 = client.post("/api/triggers/nfc/clean-kitchen", headers={"Authorization": f"Bearer {token}"})
+    assert response2.status_code == 200
+    data2 = response2.json()
+
+    assert data2["duplicate"] is False
+    assert data2["source"] == "created_from_template"
+    assert data2["quest"]["id"] != first_quest_id
+    assert data2["rewards"]["xp"] == 25
+    assert data2["rewards"]["gold"] == 15
+
+    response = client.get("/api/users/me", headers={"Authorization": f"Bearer {token}"})
+    user = response.json()
+    assert user["xp"] == 50
+    assert user["gold_balance"] == 30

--- a/deployment/.env.staging.example
+++ b/deployment/.env.staging.example
@@ -1,0 +1,22 @@
+# Copy to /srv/majordomo-staging/.env on the server and fill in the real values.
+
+NODE_ENV=production
+SECRET_KEY=replace-with-a-random-staging-secret
+DATABASE_URL=sqlite:////data/majordomo.db
+SQL_ECHO=false
+
+# Leave blank for the reverse-proxied staging deployment.
+CORS_ORIGINS=
+
+# Optional AI integration. Usually leave blank in staging.
+GROQ_API_KEY=
+
+# Frontend build/runtime
+VITE_API_URL=/api
+FRONTEND_PORT=8080
+
+# Backend stays local-only and is exposed only for diagnostics on the host.
+BACKEND_PORT=18000
+
+# Isolated SQLite copy used by the staging stack.
+STAGING_DATA_DIR=/srv/majordomo-staging/data

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -82,6 +82,83 @@ cd /srv/majordomo
 
 Production deploys should not be run directly from unmerged feature branches unless this is an intentional emergency/manual override.
 
+## Staging stack
+
+Use staging when you need a production-shaped test against copied data, such as NFC scans, without mutating real XP/gold.
+
+Staging result:
+
+- Frontend served on port `8080`: `http://majordomo:8080`
+- Backend exposed only on `127.0.0.1:18000`
+- Frontend reverse-proxies `/api` to the staging backend
+- SQLite copied to `/srv/majordomo-staging/data/majordomo.db`
+- Containers use separate names and Compose project: `majordomo-staging`
+
+Prepare an isolated staging database on the server:
+
+```bash
+sudo mkdir -p /srv/majordomo-staging/data
+sudo cp /srv/majordomo/data/majordomo.db /srv/majordomo-staging/data/majordomo.db
+sudo chown -R "$USER":"$USER" /srv/majordomo-staging
+cp deployment/.env.staging.example /srv/majordomo-staging/.env
+```
+
+Edit `/srv/majordomo-staging/.env` and set a staging-only `SECRET_KEY`.
+
+Start staging from the checkout or worktree you want to test:
+
+```bash
+docker compose \
+  -p majordomo-staging \
+  --env-file /srv/majordomo-staging/.env \
+  -f deployment/docker-compose.yml \
+  -f deployment/docker-compose.staging.yml \
+  up -d --build
+```
+
+Check logs:
+
+```bash
+docker compose \
+  -p majordomo-staging \
+  --env-file /srv/majordomo-staging/.env \
+  -f deployment/docker-compose.yml \
+  -f deployment/docker-compose.staging.yml \
+  logs -f
+```
+
+Stop staging:
+
+```bash
+docker compose \
+  -p majordomo-staging \
+  --env-file /srv/majordomo-staging/.env \
+  -f deployment/docker-compose.yml \
+  -f deployment/docker-compose.staging.yml \
+  down
+```
+
+For NFC testing, enable a copied staging template manually:
+
+```sql
+UPDATE quest_template
+SET nfc_enabled = 1,
+    nfc_code = 'trash-bin'
+WHERE id = 42;
+```
+
+Write the temporary staging URL to the NFC tag:
+
+```text
+http://majordomo:8080/t/trash-bin
+```
+
+After production rollout, rewrite the tag without the staging port:
+
+```text
+http://majordomo/t/trash-bin
+```
+
 ## Routine operations
 
 Create a manual database backup:

--- a/deployment/docker-compose.staging.yml
+++ b/deployment/docker-compose.staging.yml
@@ -1,0 +1,12 @@
+services:
+  backend:
+    container_name: majordomo-staging-backend
+    ports: !override
+      - "127.0.0.1:${BACKEND_PORT:-18000}:8000"
+    volumes: !override
+      - ${STAGING_DATA_DIR:-/srv/majordomo-staging/data}:/data
+
+  frontend:
+    container_name: majordomo-staging-frontend
+    ports: !override
+      - "${FRONTEND_PORT:-8080}:80"

--- a/docs/archive/specific/NFC_SETUP.md
+++ b/docs/archive/specific/NFC_SETUP.md
@@ -1,99 +1,118 @@
 # NFC Trigger Setup Guide
 
+Last verified: 2026-04-27
+
 ## Overview
-NFC tags are simple triggers that link to quest completion. When scanned, they automatically complete a quest template and award XP/Gold to the authenticated user.
+
+NFC tags link to a Majordomo trigger URL. When a logged-in user scans a tag, Majordomo completes a quest for that user and shows the reward result.
+
+Current behavior:
+
+- NFC tags point to a public NFC code, not a raw template ID.
+- The NFC code resolves to one NFC-enabled quest template.
+- If the user has an active quest from the scanned template, the oldest active matching quest is completed.
+- If there is no active matching quest, Majordomo creates a quest instance from the template and completes it immediately.
+- Duplicate scans of the same NFC template by the same user within 30 seconds are ignored and do not award rewards again.
+- If the user is not logged in, the app sends them to login and then resumes the trigger URL.
 
 ## Backend
-- **Endpoint:** `POST /api/triggers/quest/{quest_template_id}`
-- **Authentication:** Required (JWT Bearer token)
-- **Response:** Quest completion details + rewards + updated user stats
+
+- Endpoint: `POST /api/triggers/nfc/{nfc_code}`
+- Authentication: required JWT Bearer token
+- Duplicate cooldown: 30 seconds per `home_id + user_id + quest_template_id`
+- Response: quest completion details, rewards, user stats, trigger source, and duplicate status
 
 ## Frontend
-- **Route:** `/trigger/quest/:questTemplateId`
-- **Auth Handling:** Automatically redirects to login if not authenticated
-- **Post-Login Flow:** Redirects back to trigger URL and completes quest
-- **UX:** Shows completion animation, rewards display, auto-returns to board in 3 seconds
+
+- Route: `/t/:nfcCode`
+- Production URL shape: `http://majordomo/t/<nfc_code>`
+- Dev URL shape: `http://majordomo:3000/t/<nfc_code>`
+- API wiring:
+  - Production Docker/Caddy serves the frontend on port 80 and reverse-proxies `/api` to the backend.
+  - Vite dev derives `http://<same-host>:8000/api` when opened on port 3000.
 
 ## NFC Tag Configuration
 
-### What to Write
-Write a URI record to your NFC tag with the following format:
+Write a URI record to the tag:
 
+```text
+http://majordomo/t/<nfc_code>
 ```
-https://<your-lan-ip>:3000/trigger/quest/<quest_template_id>
+
+Example:
+
+```text
+http://majordomo/t/trash-bin
 ```
 
-**Examples:**
-- If your laptop IP is `192.168.1.100`: `https://192.168.1.100:3000/trigger/quest/1`
-- If using mDNS: `https://majordomo.local:3000/trigger/quest/1`
+Use the Tailscale/MagicDNS hostname, not a LAN IP. The tag should not include `localhost`, a laptop IP, or the dev port unless you are intentionally testing against the Vite dev server.
 
-### How to Write the Tag
-1. Use an NFC writing app on your phone (e.g., TagWriter by NXP, Trigger)
-2. Create a new URI record
-3. Paste the URL above
-4. Write to your NFC tag
-5. Test by scanning
+## Enabling A Template For NFC
 
-## Quest Template IDs
-Reference seeded templates (from seed.py):
-- `1`: Clean Kitchen (Standard)
-- `2`: Do Laundry (Standard)
-- `3`: Vacuum Living Room (Corrupted)
-- `4`: Walk the Dog (Bounty)
-- `5`: Mow Lawn (Bounty)
-- `6`: Take out Trash (Corrupted)
+Open the template in template edit mode and use the NFC section:
 
-Create more templates via the API and note their IDs for new tags.
+- Enable `Use for NFC`
+- Set or adjust the `NFC code`
+- Copy the generated `Tag URL`
 
-## Testing Flow
+Example:
 
-### Without NFC Hardware
-1. Start both servers:
+- `NFC code`: `trash-bin`
+- `Tag URL`: `http://majordomo/t/trash-bin`
+
+Keep `nfc_code` stable once written to a physical tag. The tag can keep working through template name/reward/schedule edits as long as the code remains assigned to that template.
+
+## Testing Without NFC Hardware
+
+Production-style test:
+
+1. Ensure the server stack is running and reachable through Tailscale.
+2. Open:
+
+   ```text
+   http://majordomo/t/<nfc_code>
+   ```
+
+3. Log in if prompted.
+4. Confirm the quest completion screen appears and stays visible until `Return to Board` is pressed.
+5. Open the same URL again immediately and confirm it shows the duplicate cooldown state.
+
+Dev test:
+
+1. Start backend:
+
    ```bash
-   cd backend && uv run python main.py
-   cd frontend && bun run dev
+   cd backend
+   uv run python main.py
    ```
 
-2. Manually open the trigger URL:
+2. Start frontend:
+
+   ```bash
+   cd frontend
+   bun run dev
    ```
-   http://localhost:3000/trigger/quest/1
+
+3. Open:
+
+   ```text
+   http://majordomo:3000/t/<nfc_code>
    ```
 
-3. Login with seeded credentials:
-   - Username: `alice`, `bob`, or `charlie`
-   - Password: `alice123`, `bob123`, `charlie123`
-   - Home ID: `1`
+The Vite config allows the `majordomo` host for this flow.
 
-4. Quest completes and shows rewards
+## Testing With NFC Hardware
 
-### With NFC Hardware
-1. Ensure servers running on `0.0.0.0:8000` and `localhost:3000`
-2. Phone on same LAN as laptop
-3. Open browser, navigate to `http://<your-laptop-ip>:3000`, login
-4. Scan NFC tag with phone
-5. App triggers quest completion
-6. See animation + rewards
-7. Auto-return to board
+1. Confirm the phone is connected to Tailscale and can open `http://majordomo`.
+2. Open the app once and log in on the phone.
+3. Write the production trigger URL to the NFC tag.
+4. Scan the tag.
+5. Confirm completion rewards.
+6. Scan again immediately and confirm no second reward is awarded.
 
-## Server Configuration
-To allow phone access over LAN:
+## Operational Notes
 
-**Backend:** Already configured for `0.0.0.0:8000` in `backend/main.py`
-
-**Frontend:**
-- Dev server binds to all interfaces automatically
-- Access via `http://<your-ip>:3000` from any device on LAN
-
-## Quest Type System
-Each quest instance inherits `quest_type` from its template:
-- `standard`: Normal quest (gold borders)
-- `bounty`: Higher value quest (purple borders)
-- `corrupted`: Urgent/overdue quest (red borders)
-
-Types are for visual distinction and future mechanic variation.
-
-## Future Enhancements
-- **Zone Mappings**: Map physical locations to quest templates (rotate which quest a zone points to)
-- **Cooldown**: Prevent scanning same tag multiple times in short window
-- **Activity Log**: Track all NFC scans per user/zone
-- **Analytics**: Dashboard showing which zones are scanned most
+- The production Docker deployment should keep `VITE_API_URL=/api`.
+- The backend is only exposed on `127.0.0.1:8000`; Caddy handles browser access through `/api`.
+- Tailscale hostname resolution must make `majordomo` resolve on the scanning device.
+- NFC rewards now use the same completion logic as board completion: bounty, corruption/shield, XP boost, participant reward rows, and achievements stay aligned.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -61,7 +61,7 @@ bun run build
 - `/board`
 - `/profile`
 - `/market`
-- `/trigger/quest/:questTemplateId`
+- `/t/:nfcCode`
 - `/playground` (UI/dev)
 
 ## API wiring

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -92,7 +92,7 @@ function App() {
           <Route path="/board" element={<Board />} />
           <Route path="/profile" element={<Profile />} />
           <Route path="/market" element={<Market />} />
-          <Route path="/trigger/quest/:questTemplateId" element={<NFCTrigger />} />
+          <Route path="/t/:nfcCode" element={<NFCTrigger />} />
           <Route path="/playground" element={<QuestCardPlayground />} />
           <Route path="/" element={<Navigate to="/board" replace />} />
         </Routes>

--- a/frontend/src/components/CreateQuestForm.tsx
+++ b/frontend/src/components/CreateQuestForm.tsx
@@ -502,6 +502,18 @@ export default function CreateQuestForm({ token, onQuestCreated, onClose }: Crea
                                 )}
                             </div>
                             <div className="flex gap-2 ml-4">
+                              {template.nfc_enabled && (
+                                <span
+                                  className="text-xs font-serif px-2 py-1"
+                                  style={{
+                                    color: COLORS.greenSuccess,
+                                    backgroundColor: "rgba(34, 197, 94, 0.12)",
+                                    border: `1px solid ${COLORS.greenSuccess}`,
+                                  }}
+                                >
+                                  NFC
+                                </span>
+                              )}
                               <span
                                 className="text-xs font-serif px-2 py-1"
                                 style={{

--- a/frontend/src/components/EditQuestModal.tsx
+++ b/frontend/src/components/EditQuestModal.tsx
@@ -9,7 +9,10 @@ import { useAuth } from "../contexts/AuthContext";
 import ModalShell from "./modal/ModalShell";
 import { buildSchedule, parseSchedule, type QuestRecurrence } from "../utils/schedule";
 import { sortHomeUsers } from "../utils/homeUsers";
+import { copyTextToClipboard } from "../utils/clipboard";
 import {
+  buildSuggestedNfcCode,
+  buildNfcTagUrl,
   buildStandaloneQuestUpdateData,
   CORRUPTION_TIMER_PRESETS,
   CORRUPTION_TIMER_UNITS,
@@ -20,6 +23,8 @@ import {
   getMaxCorruptionTimerAmount,
   getEditQuestModalLabels,
   isCorruptionTimerPreset,
+  MAX_NFC_CODE_LENGTH,
+  normalizeNfcCode,
   normalizeCustomCorruptionTimerAmount,
   toDueInHoursStateValue,
   type CorruptionTimerUnit,
@@ -100,6 +105,10 @@ export default function EditQuestModal({
   const [originalRecurrence, setOriginalRecurrence] = useState<QuestRecurrence>("one-off");
   const [saveAsTemplate, setSaveAsTemplate] = useState(initialSaveAsTemplate);
   const [homeUsers, setHomeUsers] = useState<User[]>([]);
+  const [templateTitle, setTemplateTitle] = useState(initialData?.title || "");
+  const [nfcEnabled, setNfcEnabled] = useState(false);
+  const [nfcCode, setNfcCode] = useState("");
+  const [copiedNfcUrl, setCopiedNfcUrl] = useState(false);
   const getInitialParticipantIds = useCallback(() => {
     if (targetParticipantUserIds && targetParticipantUserIds.length > 0) {
       return targetParticipantUserIds;
@@ -128,6 +137,14 @@ export default function EditQuestModal({
   const [corruptionTimerMode, setCorruptionTimerMode] = useState<CorruptionTimerMode>("preset");
   const [customDueAmount, setCustomDueAmount] = useState("2");
   const [customDueUnit, setCustomDueUnit] = useState<CorruptionTimerUnit>("days");
+  const normalizedNfcCode = normalizeNfcCode(nfcCode);
+  const suggestedNfcCode = buildSuggestedNfcCode(templateTitle || "quest-tag");
+  const nfcTagUrl = normalizedNfcCode
+    ? buildNfcTagUrl(
+        normalizedNfcCode,
+        typeof window !== "undefined" ? window.location.origin : "http://majordomo"
+      )
+    : "";
 
   const setCorruptionTimerFromHours = useCallback((nextDueInHours?: number | null) => {
     setDueInHours(toDueInHoursStateValue(nextDueInHours));
@@ -167,6 +184,9 @@ export default function EditQuestModal({
       try {
         if (isCreateMode) {
           // CREATE MODE (Random): Use provided initial data
+          setTemplateTitle(initialData.title);
+          setNfcEnabled(false);
+          setNfcCode("");
           setDisplayName(initialData.display_name || "");
           setDescription(initialData.description || "");
 
@@ -195,6 +215,9 @@ export default function EditQuestModal({
           }
 
           const response = await api.quests.getTemplate(templateId, token);
+          setTemplateTitle(response.title);
+          setNfcEnabled(response.nfc_enabled);
+          setNfcCode(response.nfc_code || "");
 
           // Fetch user's subscriptions
           const subscriptions = await api.subscriptions.getAll(token);
@@ -253,6 +276,9 @@ export default function EditQuestModal({
             });
           }
 
+          setTemplateTitle(response.template?.title || response.title);
+          setNfcEnabled(false);
+          setNfcCode("");
           setDisplayName(response.display_name || "");
           setDescription(response.description || "");
 
@@ -373,6 +399,11 @@ export default function EditQuestModal({
           // Don't call onClose - parent's onSave callback handles closing
         } else if (templateId) {
           // EDIT TEMPLATE MODE: Update template and subscriptions
+          const resolvedNfcCode = normalizedNfcCode || null;
+          if (nfcEnabled && !resolvedNfcCode) {
+            throw new Error("NFC code is required when NFC is enabled");
+          }
+
           const updateData = {
             ...(displayName.trim() && { display_name: displayName.trim() }),
             ...(description.trim() && { description: description.trim() }),
@@ -382,6 +413,8 @@ export default function EditQuestModal({
             recurrence: recurrence,
             schedule: schedule,
             due_in_hours: dueInHoursValue,
+            nfc_enabled: nfcEnabled,
+            nfc_code: resolvedNfcCode,
           };
 
           await api.quests.updateTemplate(templateId, updateData, token);
@@ -494,6 +527,8 @@ export default function EditQuestModal({
       scheduleDay,
       scheduleDayOfMonth,
       dueInHours,
+      nfcEnabled,
+      normalizedNfcCode,
       selectedParticipantIds,
       token,
       userId,
@@ -554,6 +589,23 @@ export default function EditQuestModal({
         ? current.filter((id) => id !== participantId)
         : [...current, participantId]
     );
+  };
+
+  const handleToggleNfcEnabled = (enabled: boolean) => {
+    setNfcEnabled(enabled);
+    if (enabled && !normalizedNfcCode) {
+      setNfcCode(suggestedNfcCode);
+    }
+  };
+
+  const handleCopyNfcUrl = async () => {
+    if (!nfcTagUrl) return;
+
+    const copied = await copyTextToClipboard(nfcTagUrl);
+    if (!copied) return;
+
+    setCopiedNfcUrl(true);
+    window.setTimeout(() => setCopiedNfcUrl(false), 2000);
   };
 
   return (
@@ -1212,6 +1264,117 @@ export default function EditQuestModal({
                     )}
                   </div>
                 )}
+
+              {isTemplateDefaultsMode && (
+                <div
+                  className="mb-6 p-4 rounded-lg"
+                  style={{
+                    backgroundColor: `rgba(212, 175, 55, 0.1)`,
+                    borderColor: COLORS.gold,
+                    borderWidth: "1px",
+                  }}
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div>
+                      <h3
+                        className="text-sm uppercase tracking-wider font-serif"
+                        style={{ color: COLORS.gold }}
+                      >
+                        NFC Trigger
+                      </h3>
+                      <p className="mt-1 text-xs font-serif" style={{ color: COLORS.parchment }}>
+                        Scanning the tag completes your active quest from this template or creates
+                        and completes one if none exists.
+                      </p>
+                    </div>
+                    <label className="inline-flex items-center gap-2 font-serif text-sm">
+                      <input
+                        type="checkbox"
+                        checked={nfcEnabled}
+                        onChange={(e) => handleToggleNfcEnabled(e.target.checked)}
+                        className="w-4 h-4"
+                        style={{ accentColor: COLORS.gold }}
+                        disabled={saving}
+                      />
+                      <span style={{ color: COLORS.gold }}>Use for NFC</span>
+                    </label>
+                  </div>
+
+                  {nfcEnabled && (
+                    <div className="mt-4 space-y-4">
+                      <div>
+                        <label
+                          className="block text-xs uppercase tracking-wider mb-1 font-serif"
+                          style={{ color: COLORS.parchment }}
+                        >
+                          NFC Code
+                        </label>
+                        <input
+                          type="text"
+                          value={nfcCode}
+                          onChange={(e) => setNfcCode(normalizeNfcCode(e.target.value))}
+                          placeholder={suggestedNfcCode || "trash-bin"}
+                          className="w-full px-3 py-2 font-serif focus:outline-none transition-all"
+                          style={{
+                            backgroundColor: COLORS.black,
+                            borderColor: COLORS.gold,
+                            borderWidth: "2px",
+                            color: COLORS.parchment,
+                          }}
+                          disabled={saving}
+                        />
+                        <p
+                          className="mt-1 text-xs font-serif italic"
+                          style={{ color: COLORS.brown }}
+                        >
+                          Lowercase letters, numbers, and dashes only. Suggested codes are capped at{" "}
+                          {MAX_NFC_CODE_LENGTH} characters. Changing the code means rewriting the
+                          physical tag.
+                        </p>
+                      </div>
+
+                      <div>
+                        <label
+                          className="block text-xs uppercase tracking-wider mb-1 font-serif"
+                          style={{ color: COLORS.parchment }}
+                        >
+                          Tag URL
+                        </label>
+                        <div className="flex flex-col gap-2 md:flex-row">
+                          <input
+                            type="text"
+                            value={nfcTagUrl}
+                            readOnly
+                            className="w-full px-3 py-2 font-serif focus:outline-none"
+                            style={{
+                              backgroundColor: COLORS.black,
+                              borderColor: COLORS.gold,
+                              borderWidth: "2px",
+                              color: COLORS.parchment,
+                            }}
+                          />
+                          <button
+                            type="button"
+                            onClick={handleCopyNfcUrl}
+                            className="px-4 py-2 font-serif text-xs uppercase tracking-wider transition-all"
+                            style={{
+                              backgroundColor: copiedNfcUrl
+                                ? COLORS.gold
+                                : `rgba(212, 175, 55, 0.2)`,
+                              border: `1px solid ${COLORS.gold}`,
+                              color: copiedNfcUrl ? COLORS.darkPanel : COLORS.gold,
+                              cursor: nfcTagUrl ? "pointer" : "not-allowed",
+                            }}
+                            disabled={saving || !nfcTagUrl}
+                          >
+                            {copiedNfcUrl ? "Copied" : "Copy URL"}
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
 
               {/* Sliders */}
               <div

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -67,7 +67,7 @@ export default function Login() {
       const params = new URLSearchParams(window.location.search);
       const nextUrl = params.get("next");
 
-      if (nextUrl) {
+      if (nextUrl && nextUrl.startsWith("/") && !nextUrl.startsWith("//")) {
         navigate(nextUrl);
       }
     } catch (err) {

--- a/frontend/src/components/editQuestModalHelpers.ts
+++ b/frontend/src/components/editQuestModalHelpers.ts
@@ -51,6 +51,7 @@ interface WaitForScribeContentOptions<T extends ScribeQuestSnapshot> {
 export type CorruptionTimerUnit = "hours" | "days" | "weeks";
 
 export const MAX_DUE_IN_HOURS = 8760;
+export const MAX_NFC_CODE_LENGTH = 48;
 
 export const CORRUPTION_TIMER_PRESETS = [
   { label: "None", hours: 0 },
@@ -178,6 +179,37 @@ export function buildStandaloneQuestUpdateData({
       participant_user_ids: participantIds,
     }),
   };
+}
+
+export function normalizeNfcCode(value: string, maxLength: number = MAX_NFC_CODE_LENGTH): string {
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+
+  return trimNfcCodeToMaxLength(normalized, maxLength);
+}
+
+export function trimNfcCodeToMaxLength(
+  normalizedCode: string,
+  maxLength: number = MAX_NFC_CODE_LENGTH
+): string {
+  return normalizedCode.slice(0, maxLength).replace(/-+$/g, "");
+}
+
+export function buildSuggestedNfcCode(
+  value: string,
+  maxLength: number = MAX_NFC_CODE_LENGTH
+): string {
+  return trimNfcCodeToMaxLength(normalizeNfcCode(value, maxLength), maxLength);
+}
+
+export function buildNfcTagUrl(nfcCode: string, origin: string): string {
+  return `${origin.replace(/\/+$/, "")}/t/${encodeURIComponent(nfcCode)}`;
 }
 
 export function deriveDifficultySlidersFromXP(xpReward?: number): DifficultySliders {

--- a/frontend/src/pages/NFCTrigger.tsx
+++ b/frontend/src/pages/NFCTrigger.tsx
@@ -1,51 +1,57 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { api } from "../services/api";
+import { api, isRequestError } from "../services/api";
 import { COLORS } from "../constants/colors";
 import { useAuth } from "../contexts/AuthContext";
-import type { QuestCompleteResponse } from "../types/api";
+import type { TriggerQuestResponse } from "../types/api";
 
-interface NFCTriggerResult extends QuestCompleteResponse {
-  user_stats: {
-    level: number;
-    xp: number;
-    gold: number;
-  };
-}
+const SHARED_QUEST_ERROR_FRAGMENT = "shared quest";
 
 export default function NFCTrigger() {
-  const { questTemplateId } = useParams<{ questTemplateId: string }>();
+  const { nfcCode } = useParams<{ nfcCode: string }>();
   const navigate = useNavigate();
-  const [result, setResult] = useState<NFCTriggerResult | null>(null);
+  const requestKeyRef = useRef<string | null>(null);
+  const [result, setResult] = useState<TriggerQuestResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
-  const { token } = useAuth();
+  const { token, logout } = useAuth();
 
   useEffect(() => {
+    const nextUrl = `/t/${nfcCode ?? ""}`;
+
     if (!token) {
-      // Not logged in, redirect to login with next param
-      const nextUrl = `/trigger/quest/${questTemplateId}`;
       navigate(`/?next=${encodeURIComponent(nextUrl)}`);
       return;
     }
 
-    // Logged in, trigger the quest
+    const requestKey = `${token}:${nfcCode ?? ""}`;
+    if (requestKeyRef.current === requestKey) return;
+    requestKeyRef.current = requestKey;
+
     const triggerQuest = async () => {
       try {
-        const templateId = parseInt(questTemplateId || "0");
-        const data = await api.triggers.quest(templateId, token);
+        if (!nfcCode) {
+          throw new Error("Invalid quest trigger");
+        }
+
+        const data = await api.triggers.nfc(nfcCode, token);
         setResult(data);
         setError(null);
-        // Auto-return to board after 3 seconds
-        setTimeout(() => navigate("/board"), 3000);
+        setLoading(false);
       } catch (err) {
+        if (isRequestError(err) && err.status === 401) {
+          logout();
+          navigate(`/?next=${encodeURIComponent(nextUrl)}`);
+          return;
+        }
+
         setError(err instanceof Error ? err.message : "Failed to trigger quest");
         setLoading(false);
       }
     };
 
     triggerQuest();
-  }, [questTemplateId, token, navigate]);
+  }, [nfcCode, token, navigate, logout]);
 
   // Still loading
   if (loading && !result && !error) {
@@ -60,17 +66,31 @@ export default function NFCTrigger() {
 
   // Error state
   if (error) {
+    const isSharedQuestError = error.toLowerCase().includes(SHARED_QUEST_ERROR_FRAGMENT);
+    const errorTitle = isSharedQuestError ? "Shared Quest Found" : "Scan Failed";
+    const errorMessage = isSharedQuestError
+      ? "This tag matched a quest that is assigned to more than one player."
+      : error;
+    const errorGuidance = isSharedQuestError
+      ? "NFC only completes personal quests. Open the board to complete this shared quest there."
+      : null;
+
     return (
       <div className="text-center py-12 md:py-16">
         <h2
           className="text-2xl md:text-3xl font-serif font-bold mb-4"
           style={{ color: COLORS.redLight }}
         >
-          ⚠ Error
+          ⚠ {errorTitle}
         </h2>
         <p className="font-serif mb-6" style={{ color: COLORS.parchment }}>
-          {error}
+          {errorMessage}
         </p>
+        {errorGuidance && (
+          <p className="font-serif mb-6" style={{ color: COLORS.brown }}>
+            {errorGuidance}
+          </p>
+        )}
         <button
           onClick={() => navigate("/board")}
           className="px-6 py-2 font-serif text-sm uppercase tracking-wider transition-all"
@@ -96,13 +116,20 @@ export default function NFCTrigger() {
         </div>
         <h2
           className="text-2xl md:text-4xl font-serif font-bold mb-2"
-          style={{ color: COLORS.greenSuccess }}
+          style={{ color: result.duplicate ? COLORS.gold : COLORS.greenSuccess }}
         >
-          Quest Complete!
+          {result.duplicate ? "Already Counted" : "Quest Complete!"}
         </h2>
         <p className="text-lg md:text-2xl font-serif mb-8" style={{ color: COLORS.gold }}>
           {result.quest.display_name || result.quest.title}
         </p>
+
+        {result.duplicate && (
+          <p className="font-serif mb-8" style={{ color: COLORS.parchment }}>
+            Scan ignored for {result.cooldown_remaining_seconds ?? result.cooldown_seconds} more
+            seconds.
+          </p>
+        )}
 
         {/* Rewards Display */}
         <div className="flex flex-col md:flex-row gap-8 md:gap-12 justify-center mb-8 py-6 md:py-8">
@@ -141,9 +168,24 @@ export default function NFCTrigger() {
           </p>
         </div>
 
-        <p className="text-xs md:text-sm font-serif italic" style={{ color: COLORS.brown }}>
-          Returning to board...
-        </p>
+        <div className="flex flex-col items-center gap-3">
+          <p className="text-xs md:text-sm font-serif italic" style={{ color: COLORS.brown }}>
+            Review the result, then head back when you are ready.
+          </p>
+          <button
+            type="button"
+            onClick={() => navigate("/board")}
+            className="px-6 py-2 font-serif text-sm uppercase tracking-wider transition-all"
+            style={{
+              backgroundColor: "rgba(212, 175, 55, 0.14)",
+              borderColor: COLORS.gold,
+              borderWidth: "1px",
+              color: COLORS.gold,
+            }}
+          >
+            Return to Board
+          </button>
+        </div>
       </div>
     );
   }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,5 +1,6 @@
 import type {
   LoginResponse,
+  TriggerQuestResponse,
   User,
   Quest,
   QuestTemplate,
@@ -19,6 +20,21 @@ import type {
   UpcomingSubscription,
   ConvertToTemplateRequest,
 } from "../types/api";
+
+export interface RequestError extends Error {
+  status: number;
+}
+
+export const isRequestError = (error: unknown): error is RequestError =>
+  error instanceof Error &&
+  "status" in error &&
+  typeof (error as { status?: unknown }).status === "number";
+
+const createRequestError = (status: number, message: string): RequestError => {
+  const error = new Error(message) as RequestError;
+  error.status = status;
+  return error;
+};
 
 const getAPIURL = (): string => {
   if (import.meta.env.VITE_API_URL) {
@@ -70,12 +86,14 @@ const requestJSON = async <T>(
 ): Promise<T> => {
   const res = await fetch(`${API_URL}${path}`, options);
   if (!res.ok) {
+    let message = fallbackError;
     try {
       const error = await res.json();
-      throw new Error(extractErrorMessage(error, fallbackError));
+      message = extractErrorMessage(error, fallbackError);
     } catch {
-      throw new Error(fallbackError);
+      message = fallbackError;
     }
+    throw createRequestError(res.status, message);
   }
 
   return res.json();
@@ -87,7 +105,7 @@ const requestVoid = async (
   fallbackError: string
 ): Promise<void> => {
   const res = await fetch(`${API_URL}${path}`, options);
-  if (!res.ok) throw new Error(fallbackError);
+  if (!res.ok) throw createRequestError(res.status, fallbackError);
 };
 
 export const api = {
@@ -359,16 +377,9 @@ export const api = {
   },
 
   triggers: {
-    quest: async (
-      questTemplateId: number,
-      token: string
-    ): Promise<
-      QuestCompleteResponse & { user_stats: { level: number; xp: number; gold: number } }
-    > =>
-      requestJSON<
-        QuestCompleteResponse & { user_stats: { level: number; xp: number; gold: number } }
-      >(
-        `/triggers/quest/${questTemplateId}`,
+    nfc: async (nfcCode: string, token: string): Promise<TriggerQuestResponse> =>
+      requestJSON<TriggerQuestResponse>(
+        `/triggers/nfc/${encodeURIComponent(nfcCode)}`,
         {
           method: "POST",
           headers: buildHeaders(token),

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -15,6 +15,8 @@ export interface QuestTemplate {
   last_generated_at: string | null;
   due_in_hours: number | null;
   system: boolean;
+  nfc_enabled: boolean;
+  nfc_code: string | null;
   created_by: number;
   created_at: string;
 }
@@ -103,6 +105,27 @@ export interface QuestCompleteResponse {
     xp_boost_active?: boolean;
     xp_boost_remaining?: number;
     participants?: QuestParticipantReward[];
+    duplicate_scan?: boolean;
+    previous_xp?: number;
+    previous_gold?: number;
+  };
+  achievements?: Array<{
+    user_id: number;
+    id: number;
+    unlocked_at: string;
+  }>;
+}
+
+export interface TriggerQuestResponse extends QuestCompleteResponse {
+  success: boolean;
+  duplicate: boolean;
+  source: "active_quest" | "created_from_template" | "cooldown";
+  cooldown_seconds: number;
+  cooldown_remaining_seconds?: number;
+  user_stats: {
+    level: number;
+    xp: number;
+    gold: number;
   };
 }
 
@@ -139,6 +162,8 @@ export interface QuestTemplateCreateRequest {
   recurrence?: string;
   schedule?: string | null;
   due_in_hours?: number | null;
+  nfc_enabled?: boolean;
+  nfc_code?: string | null;
 }
 
 export interface QuestTemplateUpdateRequest {
@@ -151,6 +176,8 @@ export interface QuestTemplateUpdateRequest {
   recurrence?: string;
   schedule?: string | null;
   due_in_hours?: number | null;
+  nfc_enabled?: boolean;
+  nfc_code?: string | null;
 }
 
 export interface QuestCreateRequest {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -18,6 +18,7 @@ export default defineConfig({
       port: 3000,
     },
     allowedHosts: [
+      "majordomo",
       ".trycloudflare.com",
     ],
   },


### PR DESCRIPTION
## Summary
- replace the legacy template-id NFC flow with stable NFC codes and the `/t/:nfcCode` route
- share NFC reward handling with normal quest completion, add 30s duplicate-scan protection, and block shared active quests from being completed by NFC
- add template-editor NFC controls plus a staging compose override and deployment docs for production-shaped NFC testing

## Why
The old NFC flow was tied to a stale route shape and older reward logic. This update brings NFC back in line with the current app model, makes it usable behind `http://majordomo`, and closes the main failure cases we found in staging: duplicate scans and accidental completion of shared quests.

## Impact
- NFC-enabled templates now use explicit `nfc_enabled` and `nfc_code` metadata
- users can enable NFC in the template editor and copy the tag URL directly
- scans complete the user's personal active quest when available, otherwise create and complete a personal quest
- scans against shared active quests are rejected with guidance to complete them from the board
- staging can run on the same host with isolated copied data for phone/NFC testing

## Validation
- `uv run pytest tests/test_triggers.py`
- `bun run typecheck`
- `bun run build`
- manual staging verification on `http://majordomo:8080` for:
  - create-and-complete flow
  - active-quest completion
  - duplicate-scan cooldown
  - shared-quest rejection messaging
  - template editor NFC setup UI
